### PR TITLE
Reorganize IPS tests slightly.

### DIFF
--- a/spec/suites/ips/condition_spec.rb
+++ b/spec/suites/ips/condition_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe IPS::Condition do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('ips') }
-  let(:group) { suite.groups[1].groups[21] }
+  let(:group) { suite.groups.first.groups[1].groups[3] }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'ips') }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }

--- a/spec/suites/ips/document_operation_spec.rb
+++ b/spec/suites/ips/document_operation_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe IPS::DocumentOperation do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('ips') }
-  let(:group) { suite.groups.first.groups.first }
+  let(:group) { suite.groups.first.groups.first.groups.first }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'ips') }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }

--- a/spec/suites/ips/summary_operation_spec.rb
+++ b/spec/suites/ips/summary_operation_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe IPS::SummaryOperation do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('ips') }
-  let(:group) { suite.groups.first.groups.last }
+  let(:group) { suite.groups.first.groups.first.groups.last }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'ips') }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }

--- a/suites/ips/suite.rb
+++ b/suites/ips/suite.rb
@@ -6,7 +6,7 @@ module IPS
     id 'ips'
 
     group do
-      title 'Restful API Tests'
+      title 'FHIR API Tests'
       input :url
 
       fhir_client do
@@ -14,14 +14,14 @@ module IPS
       end
 
       group do
-        title 'Operations'
+        title 'Perform Operations'
 
         group from: :ips_document_operation
         group from: :ips_summary_operation
       end
 
       group do
-        title 'Read and Validate Profiles'
+        title 'Read and Validate Resources'
 
         group from: :ips_allergy_intolerance
         group from: :ips_bundle
@@ -37,7 +37,7 @@ module IPS
         group from: :ips_medication
         group from: :ips_medication_statement
         group do
-          title 'Observation (IPS) Tests'
+          title 'Observation Resources'
           group from: :ips_observation_alcohol_use
           group from: :ips_observation_pregnancy_status
           group from: :ips_observation_pregnancy_edd

--- a/suites/ips/suite.rb
+++ b/suites/ips/suite.rb
@@ -5,50 +5,57 @@ module IPS
 
     id 'ips'
 
-    input :url
-
-    fhir_client do
-      url :url
-    end
-
     group do
-      title 'IPS Operations'
+      title 'Restful API Tests'
+      input :url
 
-      group from: :ips_document_operation
-      group from: :ips_summary_operation
+      fhir_client do
+        url :url
+      end
+
+      group do
+        title 'Operations'
+
+        group from: :ips_document_operation
+        group from: :ips_summary_operation
+      end
+
+      group do
+        title 'Read and Validate Profiles'
+
+        group from: :ips_allergy_intolerance
+        group from: :ips_bundle
+        group from: :ips_composition
+        group from: :ips_condition
+        group from: :ips_device
+        group from: :ips_device_observer
+        group from: :ips_device_use_statement
+        group from: :ips_diagnostic_report
+        group from: :ips_imaging_study
+        group from: :ips_immunization
+        group from: :ips_media_observation
+        group from: :ips_medication
+        group from: :ips_medication_statement
+        group do
+          title 'Observation (IPS) Tests'
+          group from: :ips_observation_alcohol_use
+          group from: :ips_observation_pregnancy_status
+          group from: :ips_observation_pregnancy_edd
+          group from: :ips_observation_tobacco_use
+          group from: :ips_observation_results
+          group from: :ips_observation_results_laboratory
+          group from: :ips_observation_results_pathology
+          group from: :ips_observation_results_radiology
+          group from: :ips_observation_pregnancy_outcome
+        end
+        group from: :ips_organization
+        group from: :ips_patient
+        group from: :ips_practitioner
+        group from: :ips_practitioner_role
+        group from: :ips_procedure
+        group from: :ips_specimen
+      end
     end
 
-    group do
-      title 'IPS Profiles'
-
-      group from: :ips_observation_alcohol_use
-      group from: :ips_practitioner
-      group from: :ips_observation_results_radiology
-      group from: :ips_device
-      group from: :ips_observation_results_laboratory
-      group from: :ips_bundle
-      group from: :ips_observation_results
-      group from: :ips_allergy_intolerance
-      group from: :ips_practitioner_role
-      group from: :ips_observation_pregnancy_status
-      group from: :ips_medication_statement
-      group from: :ips_patient
-      group from: :ips_observation_pregnancy_edd
-      group from: :ips_specimen
-      group from: :ips_immunization
-      group from: :ips_device_observer
-      group from: :ips_composition
-      group from: :ips_organization
-      group from: :ips_imaging_study
-      group from: :ips_media_observation
-      group from: :ips_device_use_statement
-      group from: :ips_condition
-      group from: :ips_observation_tobacco_use
-      group from: :ips_observation_results_pathology
-      group from: :ips_diagnostic_report
-      group from: :ips_medication
-      group from: :ips_procedure
-      group from: :ips_observation_pregnancy_outcome
-    end
   end
 end


### PR DESCRIPTION
* Added a 'FHIR API' section, with the intent of adding a 'FHIR Document' section (given this IG's lack of need for the actual API)
* Reordered and renamed the profile tests
* Grouped all observation profile tests under a single group
* Created a distinct input for every Operation resource type

.![Screen Shot 2021-05-17 at 3 33 22 PM](https://user-images.githubusercontent.com/412901/118546166-8fd97c00-b725-11eb-9a36-19c7db2ae3b0.png)