### PR TITLE
Minor fixes for issues identified in connectathon

### DIFF
--- a/config/boot/entities.rb
+++ b/config/boot/entities.rb
@@ -2,6 +2,8 @@ Inferno::Application.boot(:entities) do
   init do
     require_relative(File.join(Inferno::Application.root, 'lib', 'inferno', 'exceptions'))
 
+    require_relative(File.join(Inferno::Application.root, 'lib', 'inferno', 'entities', 'attributes.rb'))
+    require_relative(File.join(Inferno::Application.root, 'lib', 'inferno', 'entities', 'entity.rb'))
     Dir.glob(File.join(Inferno::Application.root, 'lib', 'inferno', 'entities', '*')).each do |path|
       require_relative path
     end

--- a/lib/inferno/entities/message.rb
+++ b/lib/inferno/entities/message.rb
@@ -1,5 +1,3 @@
-require_relative 'attributes'
-
 module Inferno
   module Entities
     # A `Message` represents a message generated during a test.

--- a/lib/inferno/entities/result.rb
+++ b/lib/inferno/entities/result.rb
@@ -1,5 +1,3 @@
-require_relative 'attributes'
-
 module Inferno
   module Entities
     # A `Result` represents the result of running a `Test`, `TestGroup`,

--- a/suites/ips/document_operation.rb
+++ b/suites/ips/document_operation.rb
@@ -121,9 +121,9 @@ module IPS
     end
 
     test do
-      title 'IPS Server returns Bundle resource containing valid IPS MedicaitonStatement entry'
+      title 'IPS Server returns Bundle resource containing valid IPS MedicationStatement entry'
       description %(
-        IPS Server return valid IPS MedicaitonStatement resource in the Bundle as first entry
+        IPS Server return valid IPS MedicationStatement resource in the Bundle as first entry
       )
       # link 'http://hl7.org/fhir/uv/ips/StructureDefinition-MedicationStatement-uv-ips.html'
       uses_request :document_operation

--- a/suites/ips/summary_operation.rb
+++ b/suites/ips/summary_operation.rb
@@ -70,9 +70,9 @@ module IPS
     end
 
     test do
-      title 'IPS Server returns Bundle resource containing valid IPS MedicaitonStatement entry'
+      title 'IPS Server returns Bundle resource containing valid IPS MedicationStatement entry'
       description %(
-        IPS Server return valid IPS MedicaitonStatement resource in the Bundle as first entry
+        IPS Server return valid IPS MedicationStatement resource in the Bundle as first entry
       )
       # link 'http://hl7.org/fhir/uv/ips/StructureDefinition-MedicationStatement-uv-ips.html'
       uses_request :summary_operation


### PR DESCRIPTION
The load order change is to fix an issue that occurred when running the Docker image on a linux host.