### PR TITLE
FI-1142: Serve custom endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'health_cards'
 
 group :development, :test do
   gem 'pry'
-  gem 'sinatra'
   gem 'pry-byebug'
   gem 'rubocop', '~> 1.9'
   gem 'rubocop-rake', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'health_cards'
 
 group :development, :test do
   gem 'pry'
+  gem 'sinatra'
   gem 'pry-byebug'
   gem 'rubocop', '~> 1.9'
   gem 'rubocop-rake', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,8 +133,6 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.5)
@@ -161,8 +159,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
-    rack-protection (2.1.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
@@ -214,11 +210,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.1.0)
-      tilt (~> 2.0)
     sqlite3 (1.4.2)
     tilt (2.0.10)
     transproc (1.1.1)
@@ -266,7 +257,6 @@ DEPENDENCIES
   rubocop-sequel
   sequel
   simplecov
-  sinatra
   sqlite3
   webmock
   yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.5)
@@ -159,6 +161,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
@@ -210,6 +214,11 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
     sqlite3 (1.4.2)
     tilt (2.0.10)
     transproc (1.1.1)
@@ -257,6 +266,7 @@ DEPENDENCIES
   rubocop-sequel
   sequel
   simplecov
+  sinatra
   sqlite3
   webmock
   yard

--- a/client/src/components/LandingPage/__mocked_data__/mockData.ts
+++ b/client/src/components/LandingPage/__mocked_data__/mockData.ts
@@ -1,16 +1,16 @@
 import { TestSuite } from 'models/testSuiteModels';
 
 export const mockedTestSuitesReturnValue: TestSuite[] = [
-  { id: 'DemoIG_STU1::DemoSuite', title: 'Demonstration Suite', description: '' },
+  { id: 'demo', title: 'Demonstration Suite', description: '' },
   { id: 'infra_test', title: 'Infrastructure Test', description: '' },
 ];
 
 export const mockedPostTestSuiteResponse = {
   id: '4402e8b1-8cd3-4dad-ba80-ffa593f26be4',
   test_suite: {
-    id: 'DemoIG_STU1::DemoSuite',
+    id: 'demo',
     test_groups: [],
     title: 'Demonstration Suite',
   },
-  test_suite_id: 'DemoIG_STU1::DemoSuite',
+  test_suite_id: 'demo',
 };

--- a/client/src/components/TestSuite/TestSuiteDetails/ResultIcon.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/ResultIcon.tsx
@@ -2,7 +2,8 @@ import React, { FC, Fragment } from 'react';
 import { Result } from 'models/testSuiteModels';
 import { Tooltip } from '@material-ui/core';
 import { green, red } from '@material-ui/core/colors';
-import CheckIcon from '@material-ui/icons/Check';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import CancelIcon from '@material-ui/icons/Cancel';
 import ErrorIcon from '@material-ui/icons/Error';
 import { RedoOutlined } from '@material-ui/icons';
@@ -17,7 +18,7 @@ const ResultIcon: FC<ResultIconProps> = ({ result }) => {
       case 'pass':
         return (
           <Tooltip title="passed">
-            <CheckIcon
+            <CheckCircleIcon
               style={{ color: green[500] }}
               data-testid={`${result.id}-${result.result}`}
             />
@@ -45,6 +46,12 @@ const ResultIcon: FC<ResultIconProps> = ({ result }) => {
         return (
           <Tooltip title="error">
             <ErrorIcon style={{ color: red[500] }} data-testid={`${result.id}-${result.result}`} />
+          </Tooltip>
+        );
+      case 'wait':
+        return (
+          <Tooltip title="wait">
+            <AccessTimeIcon data-testid={`${result.id}-${result.result}`} />
           </Tooltip>
         );
       default:

--- a/client/src/components/TestSuite/__mocked_data__/mockData.ts
+++ b/client/src/components/TestSuite/__mocked_data__/mockData.ts
@@ -3,7 +3,7 @@ export const mockedTestRunReturnValue = {
   inputs: null,
   results: null,
   status: null,
-  test_group_id: 'DemoIG_STU1::DemoSuite-Group01',
+  test_group_id: 'demo-Group01',
   test_session_id: 'test session id',
 };
 

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -1,9 +1,9 @@
 require_relative 'groups/demo_group'
-require 'sinatra/base'
 
 module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
   class DemoSuite < Inferno::TestSuite
     title 'Demonstration Suite'
+    id 'demo'
 
     # Ideas:
     # * Suite metadata (name, associated ig, version, etc etc)
@@ -45,42 +45,20 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       end
     end
 
-    class ExampleController
-      include Hanami::Action
-
-      def self.call(params)
-        new.call(params)
-      end
-
-      def call(_params)
-        self.body = 'ExampleRoute Response'
-      end
-    end
-
-    class ExampleApp < Sinatra::Base
-      get '/' do
-        'App Response'
-      end
-
-      get '/2' do
-        'App Response 2'
-      end
-    end
-
-    route :get, '/proc', ->(_env) { [200, {}, ['Proc Response']] }
-
-    route :get, '/controller', ExampleController
-
-    route :all, '/app', ExampleApp
-
     group do
       id 'wait_group'
+
+      resume_test_route :get, '/resume', name: :resume do
+        request.query_parameters['xyz']
+      end
 
       test do
         run { pass }
       end
 
       test do
+        receives_request :resume
+
         run { wait(identifier: 'abc') }
       end
 

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -47,22 +47,26 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
 
     group do
       id 'wait_group'
+      title 'Wait Group'
 
       resume_test_route :get, '/resume' do
         request.query_parameters['xyz']
       end
 
       test do
+        title 'Pass test'
         run { pass }
       end
 
       test do
+        title 'Wait test'
         receives_request :resume
 
         run { wait(identifier: 'abc') }
       end
 
       test do
+        title 'Cancel test'
         run { cancel }
       end
     end

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -48,7 +48,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     group do
       id 'wait_group'
 
-      resume_test_route :get, '/resume', name: :resume do
+      resume_test_route :get, '/resume' do
         request.query_parameters['xyz']
       end
 

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -81,7 +81,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       end
 
       test do
-        run { wait }
+        run { wait(identifier: 'abc') }
       end
 
       test do

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -43,5 +43,21 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         title 'Demo Group Instance 3'
       end
     end
+
+    group do
+      id 'wait_group'
+
+      test do
+        run { pass }
+      end
+
+      test do
+        run { wait }
+      end
+
+      test do
+        run { cancel }
+      end
+    end
   end
 end

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -1,4 +1,5 @@
 require_relative 'groups/demo_group'
+require 'sinatra/base'
 
 module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
   class DemoSuite < Inferno::TestSuite

--- a/dev_suites/demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/demo_ig_stu1/demo_suite.rb
@@ -44,6 +44,34 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       end
     end
 
+    class ExampleController
+      include Hanami::Action
+
+      def self.call(params)
+        new.call(params)
+      end
+
+      def call(_params)
+        self.body = 'ExampleRoute Response'
+      end
+    end
+
+    class ExampleApp < Sinatra::Base
+      get '/' do
+        'App Response'
+      end
+
+      get '/2' do
+        'App Response 2'
+      end
+    end
+
+    route :get, '/proc', ->(_env) { [200, {}, ['Proc Response']] }
+
+    route :get, '/controller', ExampleController
+
+    route :all, '/app', ExampleApp
+
     group do
       id 'wait_group'
 

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -12,8 +12,8 @@ module SMART
       title 'SMART Group'
 
       test do
-        id 'auth_redirect'
-        title 'OAuth server redirects client browser to app redirect URI'
+        id 'ehr_launch'
+        title 'EHR redirects client browser to app launch URI'
         receives_request :launch
 
         run do

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -3,7 +3,7 @@ module SMART
     id 'smart'
     title 'SMART'
 
-    resume_test_route :get, '/launch', name: :launch do
+    resume_test_route :get, '/launch' do
       request.query_parameters['iss']
     end
 

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -90,11 +90,14 @@ module SMART
       title 'SMART Group'
 
       test do
-        id 'wait_test'
-        title 'Wait test'
+        id 'auth_redirect'
+        title 'OAuth server redirects client browser to app redirect URI'
+
+        input :url, :client_id, :auth_url, :scope
+
         run do
           wait(
-            identifier: 'abc',
+            identifier: url,
             message: "Waiting to receive a request at /custom/smart/launch with an iss of 'abc'"
           )
         end

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -4,34 +4,24 @@ require 'sinatra/base'
 
 module SMART
   class SMARTSuite < Inferno::TestSuite
-    class ExampleController
+    class LaunchRoute
       include Hanami::Action
 
       def self.call(params)
         new.call(params)
       end
 
-      def call(_params)
+      def call(params)
+        iss = params.get(:iss)
+        repo = Inferno::Repositories::TestRuns.new
+        repo.find_latest_by_suite_and_input(test_suite_id: 'smart', input_name: 'url', input_value: 'iss')
+        binding.pry
         self.body = 'ExampleRoute Response'
       end
     end
 
-    class ExampleApp < Sinatra::Base
-      get '/' do
-        'App Response'
-      end
-
-      get '/2' do
-        'App Response 2'
-      end
-    end
+    route :get, '/launch', LaunchRoute
 
     id 'smart'
-
-    route :get, '/proc', ->(_env) { [200, {}, ['Proc Response']] }
-
-    route :get, '/controller', ExampleController
-
-    route :all, '/app', ExampleApp
   end
 end

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -21,10 +21,12 @@ class ResumeTestRoute
     Inferno::Repositories::TestRuns.new
   end
 
-  # def handle_request; end
-
   def results_repo
     Inferno::Repositories::Results.new
+  end
+
+  def tests_repo
+    Inferno::Repositories::Tests.new
   end
 
   def waiting_result
@@ -44,15 +46,13 @@ class ResumeTestRoute
     )
   end
 
-  # def set_response
-  #   self.body = request.response_body
-  #   response_headers = request.response_headers.each_with_object({}) do |header, header_hash|
-  #     header_hash[header.name] = header.value
-  #   end
-  #   headers.merge!(response_headers)
-  #   request.status ||= 200
-  #   self.status = request.status
-  # end
+  def redirect_route
+    "/test_sessions/#{test_run.test_session_id}##{waiting_group_id}"
+  end
+
+  def waiting_group_id
+    tests_repo.find(waiting_result.test_id).parent.id
+  end
 
   def call(_params)
     if test_run.nil?
@@ -62,13 +62,10 @@ class ResumeTestRoute
 
     test_run_repo.update_status_and_identifier(test_run.id, 'running', nil)
 
-    # handle_request
-    # set_response
-
     update_result
     persist_request
 
-    redirect_to "/test_sessions/#{test_run.test_session_id}"
+    redirect_to redirect_route
   end
 end
 
@@ -93,11 +90,9 @@ module SMART
         id 'auth_redirect'
         title 'OAuth server redirects client browser to app redirect URI'
 
-        input :url, :client_id, :auth_url, :scope
-
         run do
           wait(
-            identifier: url,
+            identifier: 'abc',
             message: "Waiting to receive a request at /custom/smart/launch with an iss of 'abc'"
           )
         end

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -1,86 +1,13 @@
-require 'hanami-controller'
 require 'pry'
-
-class ResumeTestRoute
-  include Hanami::Action
-
-  def self.call(params)
-    new.call(params)
-  end
-
-  def request
-    @request ||= Inferno::Entities::Request.from_rack_env(@params.env)
-  end
-
-  def test_run
-    @test_run ||=
-      test_run_repo.find_latest_waiting_by_identifier(test_run_identifier)
-  end
-
-  def test_run_repo
-    Inferno::Repositories::TestRuns.new
-  end
-
-  def results_repo
-    Inferno::Repositories::Results.new
-  end
-
-  def tests_repo
-    Inferno::Repositories::Tests.new
-  end
-
-  def waiting_result
-    @waiting_result ||= results_repo.find_waiting_result(test_run_id: test_run.id)
-  end
-
-  def update_result
-    results_repo.update_result_and_message(waiting_result.id, 'pass', nil)
-  end
-
-  def persist_request
-    Inferno::Repositories::Requests.new.create(
-      request.to_hash.merge(
-        test_session_id: test_run.test_session_id,
-        result_id: waiting_result.id
-      )
-    )
-  end
-
-  def redirect_route
-    "/test_sessions/#{test_run.test_session_id}##{waiting_group_id}"
-  end
-
-  def waiting_group_id
-    tests_repo.find(waiting_result.test_id).parent.id
-  end
-
-  def call(_params)
-    if test_run.nil?
-      status(500, "Unable to find test run with identifier '#{test_run_identifier}'.")
-      return
-    end
-
-    test_run_repo.update_status_and_identifier(test_run.id, 'running', nil)
-
-    update_result
-    persist_request
-
-    redirect_to redirect_route
-  end
-end
 
 module SMART
   class SMARTSuite < Inferno::TestSuite
-    class LaunchRoute < ResumeTestRoute
-      def test_run_identifier
-        request.query_parameters['iss']
-      end
-    end
-
-    route :get, '/launch', LaunchRoute
-
     id 'smart'
     title 'SMART'
+
+    resume_test_route :get, '/launch', name: :launch do
+      request.query_parameters['iss']
+    end
 
     group do
       id 'smart_group'
@@ -89,12 +16,27 @@ module SMART
       test do
         id 'auth_redirect'
         title 'OAuth server redirects client browser to app redirect URI'
+        makes_request :launch
 
         run do
           wait(
             identifier: 'abc',
             message: "Waiting to receive a request at /custom/smart/launch with an iss of 'abc'"
           )
+        end
+      end
+
+      test do
+        title 'Check stuff from the incoming request'
+        uses_request :launch
+
+        run do
+          query_string =
+            request
+              .query_parameters
+              .map { |name, value| "#{name}=#{value}" }
+              .join('&')
+          info("Received the following query paramaters: #{query_string}")
         end
       end
     end

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -34,7 +34,7 @@ module SMART
               .query_parameters
               .map { |name, value| "#{name}=#{value}" }
               .join('&')
-          info "Received the following query paramaters: #{query_string}"
+          info "Received the following query parameters: #{query_string}"
         end
       end
     end

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -1,22 +1,87 @@
 require 'hanami-controller'
 require 'pry'
-require 'sinatra/base'
+
+class CustomRoute
+  include Hanami::Action
+
+  def self.call(params)
+    new.call(params)
+  end
+
+  def request
+    @request ||= Inferno::Entities::Request.from_rack_env(@params.env)
+  end
+
+  def find_test_run
+    Inferno::Repositories::TestRuns.new.find_latest_waiting_by_suite_and_identifier(
+      test_suite_id: 'smart',
+      identifier: test_run_identifier
+    )
+  end
+
+  def handle_request; end
+
+  def results_repo
+    Inferno::Repositories::Results.new
+  end
+
+  def waiting_result
+    @waiting_result ||= results_repo.find_waiting_result(test_run_id: test_run.id)
+  end
+
+  def update_result
+    results_repo.update_status(waiting_result.id, 'pass')
+  end
+
+  def persist_request
+    Inferno::Repositories::Requests.new.create(
+      request.to_hash.merge(
+        test_session_id: test_run.test_session_id,
+        result_id: waiting_result.id
+      )
+    )
+  end
+
+  def set_response
+    self.body = request.response_body
+    response_headers = request.response_headers.each_with_object({}) do |header, header_hash|
+      header_hash[header.name] = header.value
+    end
+    headers.merge!(response_headers)
+    request.status ||= 200
+    self.status = request.status
+  end
+
+  def call(_params)
+    test_run = find_test_run
+    if test_run.nil?
+      status(500, "Unable to find test run with identifier '#{test_run_identifier}'.")
+      return
+    end
+
+    test_run.update_status_and_clear_identifier(test_run.id, 'running')
+
+    handle_request
+    set_response
+
+    update_result
+    persist_request
+
+    # resume execution with request
+  end
+end
 
 module SMART
   class SMARTSuite < Inferno::TestSuite
-    class LaunchRoute
-      include Hanami::Action
-
-      def self.call(params)
-        new.call(params)
+    class LaunchRoute < CustomRoute
+      def test_run_identifier
+        request.query_parameters['iss']
       end
 
-      def call(params)
-        iss = params.get(:iss)
-        repo = Inferno::Repositories::TestRuns.new
-        repo.find_latest_by_suite_and_input(test_suite_id: 'smart', input_name: 'url', input_value: 'iss')
-        binding.pry
-        self.body = 'ExampleRoute Response'
+      def handle_request
+        request.response_body = 'LaunchRoute response body'
+        request.add_response_header('X-ABC', 'DEF')
+        request.status = 201
       end
     end
 

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -1,0 +1,37 @@
+require 'hanami-controller'
+require 'pry'
+require 'sinatra/base'
+
+module SMART
+  class SMARTSuite < Inferno::TestSuite
+    class ExampleController
+      include Hanami::Action
+
+      def self.call(params)
+        new.call(params)
+      end
+
+      def call(_params)
+        self.body = 'ExampleRoute Response'
+      end
+    end
+
+    class ExampleApp < Sinatra::Base
+      get '/' do
+        'App Response'
+      end
+
+      get '/2' do
+        'App Response 2'
+      end
+    end
+
+    id 'smart'
+
+    route :get, '/proc', ->(_env) { [200, {}, ['Proc Response']] }
+
+    route :get, '/controller', ExampleController
+
+    route :all, '/app', ExampleApp
+  end
+end

--- a/dev_suites/smart/smart_suite.rb
+++ b/dev_suites/smart/smart_suite.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module SMART
   class SMARTSuite < Inferno::TestSuite
     id 'smart'
@@ -16,7 +14,7 @@ module SMART
       test do
         id 'auth_redirect'
         title 'OAuth server redirects client browser to app redirect URI'
-        makes_request :launch
+        receives_request :launch
 
         run do
           wait(
@@ -36,7 +34,7 @@ module SMART
               .query_parameters
               .map { |name, value| "#{name}=#{value}" }
               .join('&')
-          info("Received the following query paramaters: #{query_string}")
+          info "Received the following query paramaters: #{query_string}"
         end
       end
     end

--- a/lib/inferno.rb
+++ b/lib/inferno.rb
@@ -12,4 +12,7 @@ require_relative 'inferno/test_runner'
 require_relative 'inferno/version'
 
 module Inferno
+  def self.routes
+    @routes ||= []
+  end
 end

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -18,13 +18,14 @@ module Inferno
 
             TestRunner
               .new(test_session: test_session, test_run: test_run)
-              .run(test_run.runnable, inputs)
+              .start(test_run.runnable, inputs)
 
             self.body = serialize(test_run)
           rescue Sequel::ValidationFailed, Sequel::ForeignKeyConstraintViolation => e
             self.body = { errors: e.message }.to_json
             self.status = 422
           rescue StandardError => e
+            Application['logger'].error(e.full_message)
             self.body = { errors: e.message }.to_json
             self.status = 500
           end

--- a/lib/inferno/apps/web/controllers/test_sessions/create.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/create.rb
@@ -12,6 +12,7 @@ module Inferno
             self.body = { errors: e.message }.to_json
             self.status = 422
           rescue StandardError => e
+            Application['logger'].error(e.full_message)
             self.body = { errors: e.message }.to_json
             self.status = 500
           end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -22,6 +22,17 @@ module Inferno
 
       get '/', to: ->(_env) { [200, {}, [client_page]] }
       get '/test_sessions/:id', to: ->(_env) { [200, {}, [client_page]] }
+
+      Inferno.routes.each do |route|
+        cleaned_id = route[:suite].id.gsub(/[^a-zA-Z\d\-._~]/, '_')
+        path = "/custom/#{cleaned_id}#{route[:path]}"
+        Application['logger'].info("Registering custom route: #{path}")
+        if route[:method] == :all
+          mount route[:handler], at: path
+        else
+          send(route[:method], path, to: route[:handler])
+        end
+      end
     end
   end
 end

--- a/lib/inferno/db/migrations/002_add_wait_support.rb
+++ b/lib/inferno/db/migrations/002_add_wait_support.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    add_column :test_runs, :identifier, String, text: true
+    add_index :test_runs, [:test_suite_id, :status, :identifier, :updated_at], concurrently: true
+  end
+end

--- a/lib/inferno/db/migrations/002_add_wait_support.rb
+++ b/lib/inferno/db/migrations/002_add_wait_support.rb
@@ -1,6 +1,6 @@
 Sequel.migration do
   change do
     add_column :test_runs, :identifier, String, text: true
-    add_index :test_runs, [:test_suite_id, :status, :identifier, :updated_at], concurrently: true
+    add_index :test_runs, [:status, :identifier, :updated_at], concurrently: true
   end
 end

--- a/lib/inferno/db/migrations/002_add_wait_support.rb
+++ b/lib/inferno/db/migrations/002_add_wait_support.rb
@@ -1,6 +1,7 @@
 Sequel.migration do
   change do
     add_column :test_runs, :identifier, String, text: true
-    add_index :test_runs, [:status, :identifier, :updated_at], concurrently: true
+    add_column :test_runs, :wait_timeout, DateTime
+    add_index :test_runs, [:status, :identifier, :wait_timeout, :updated_at], concurrently: true
   end
 end

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -89,6 +89,18 @@ module Inferno
           named_requests_made.concat(names)
         end
 
+        # Specify the name for a request received by a test
+        #
+        # @param *names [Symbol] one or more Symbols
+        def receives_request(name)
+          @incoming_request_name = name
+        end
+
+        # @api private
+        def incoming_request_name
+          @incoming_request_name
+        end
+
         # Specify the named requests used by a test
         #
         # @param *names [Symbol] one or more Symbols

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -53,8 +53,13 @@ module Inferno
       # Halt execution of the current test and wait for execution to resume.
       #
       # @param message [String]
-      def wait(message = '')
+      def wait(identifier:, message: '')
+        identifier(identifier)
         raise Exceptions::WaitException, message
+      end
+
+      def identifier(identifier = nil)
+        @identifier ||= identifier
       end
 
       # Halt execution of the current test. This provided for testing purposes

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -52,6 +52,26 @@ module Inferno
 
       # Halt execution of the current test and wait for execution to resume.
       #
+      # @see Inferno::DSL::Runnable#resume_test_route
+      # @example
+      #   resume_test_route :get, '/launch' do
+      #     request.query_parameters['iss']
+      #   end
+      #
+      #   test do
+      #     input :issuer
+      #     receives_request :launch
+      #
+      #     run do
+      #       wait(
+      #         identifier: issuer,
+      #         message: "Wating to receive a request with an issuer of #{issuer}"
+      #       )
+      #     end
+      #   end
+      # @param identifier [String] An identifier which can uniquely identify
+      #   this test run based on an incoming request. This is necessary so that
+      #   the correct test run can be resumed.
       # @param message [String]
       def wait(identifier:, message: '')
         identifier(identifier)

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -73,13 +73,21 @@ module Inferno
       #   this test run based on an incoming request. This is necessary so that
       #   the correct test run can be resumed.
       # @param message [String]
-      def wait(identifier:, message: '')
+      # @param timeout [Integer] Number of seconds to wait for an incoming
+      #   request
+      def wait(identifier:, message: '', timeout: 300)
         identifier(identifier)
+        wait_timeout(timeout)
+
         raise Exceptions::WaitException, message
       end
 
       def identifier(identifier = nil)
         @identifier ||= identifier
+      end
+
+      def wait_timeout(timeout = nil)
+        @wait_timeout ||= timeout
       end
 
       # Halt execution of the current test. This provided for testing purposes

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -49,6 +49,22 @@ module Inferno
       def omit_if(test, message = '')
         raise Exceptions::OmitException, message if test
       end
+
+      # Halt execution of the current test and wait for execution to resume.
+      #
+      # @param message [String]
+      def wait(message = '')
+        raise Exceptions::WaitException, message
+      end
+
+      # Halt execution of the current test. This provided for testing purposes
+      # and should not be used in real tests.
+      #
+      # @param message [String]
+      # @api private
+      def cancel(message = '')
+        raise Exceptions::CancelException, message
+      end
     end
   end
 end

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -75,7 +75,7 @@ module Inferno
           return
         end
 
-        test_runs_repo.clear_identifier(test_run.id)
+        test_runs_repo.mark_as_no_longer_waiting(test_run.id)
 
         update_result
         persist_request

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -8,6 +8,7 @@ module Inferno
                 requests_repo: 'repositories.requests',
                 results_repo: 'repositories.results',
                 test_runs_repo: 'repositories.test_runs',
+                test_sessions_repo: 'repositories.test_sessions',
                 tests_repo: 'repositories.tests'
               ]
 
@@ -20,6 +21,11 @@ module Inferno
       # @return [Inferno::Entities::Request]
       def request
         @request ||= Inferno::Entities::Request.from_rack_env(@params.env)
+      end
+
+      def test_session
+        @test_session ||=
+          test_sessions_repo.find(test_run.test_session_id)
       end
 
       # @api private
@@ -71,7 +77,7 @@ module Inferno
           return
         end
 
-        test_runs_repo.update_status_and_identifier(test_run.id, 'running', nil)
+        test_runs_repo.update_identifier(test_run.id, nil)
 
         update_result
         persist_request

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -2,6 +2,10 @@ require 'hanami-controller'
 
 module Inferno
   module DSL
+    # A base class for creating routes to resume test execution upon receiving
+    # an incoming request.
+    # @api private
+    # @see Inferno::DSL::Runnable#resume_test_route
     class ResumeTestRoute
       include Hanami::Action
       include Import[

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -8,7 +8,6 @@ module Inferno
                 requests_repo: 'repositories.requests',
                 results_repo: 'repositories.results',
                 test_runs_repo: 'repositories.test_runs',
-                test_sessions_repo: 'repositories.test_sessions',
                 tests_repo: 'repositories.tests'
               ]
 
@@ -21,11 +20,6 @@ module Inferno
       # @return [Inferno::Entities::Request]
       def request
         @request ||= Inferno::Entities::Request.from_rack_env(@params.env)
-      end
-
-      def test_session
-        @test_session ||=
-          test_sessions_repo.find(test_run.test_session_id)
       end
 
       # @api private

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -39,7 +39,7 @@ module Inferno
 
       # @api private
       def update_result
-        results_repo.update_result_and_message(waiting_result.id, 'pass', nil)
+        results_repo.pass_waiting_result(waiting_result.id)
       end
 
       # @api private
@@ -75,7 +75,7 @@ module Inferno
           return
         end
 
-        test_runs_repo.update_identifier(test_run.id, nil)
+        test_runs_repo.clear_identifier(test_run.id)
 
         update_result
         persist_request

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -44,7 +44,7 @@ module Inferno
           request.to_hash.merge(
             test_session_id: test_run.test_session_id,
             result_id: waiting_result.id,
-            name: request_name
+            name: test.incoming_request_name
           )
         )
       end
@@ -55,8 +55,13 @@ module Inferno
       end
 
       # @api private
+      def test
+        @test ||= tests_repo.find(waiting_result.test_id)
+      end
+
+      # @api private
       def waiting_group_id
-        tests_repo.find(waiting_result.test_id).parent.id
+        test.parent.id
       end
 
       # @api private

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -1,0 +1,78 @@
+require 'hanami-controller'
+
+module Inferno
+  module DSL
+    class ResumeTestRoute
+      include Hanami::Action
+      include Import[
+                requests_repo: 'repositories.requests',
+                results_repo: 'repositories.results',
+                test_runs_repo: 'repositories.test_runs',
+                tests_repo: 'repositories.tests'
+              ]
+
+      def self.call(params)
+        new.call(params)
+      end
+
+      # The incoming request
+      #
+      # @return [Inferno::Entities::Request]
+      def request
+        @request ||= Inferno::Entities::Request.from_rack_env(@params.env)
+      end
+
+      # @api private
+      def test_run
+        @test_run ||=
+          test_runs_repo.find_latest_waiting_by_identifier(test_run_identifier)
+      end
+
+      # @api private
+      def waiting_result
+        @waiting_result ||= results_repo.find_waiting_result(test_run_id: test_run.id)
+      end
+
+      # @api private
+      def update_result
+        results_repo.update_result_and_message(waiting_result.id, 'pass', nil)
+      end
+
+      # @api private
+      def persist_request
+        requests_repo.create(
+          request.to_hash.merge(
+            test_session_id: test_run.test_session_id,
+            result_id: waiting_result.id,
+            name: request_name
+          )
+        )
+      end
+
+      # @api private
+      def redirect_route
+        "/test_sessions/#{test_run.test_session_id}##{waiting_group_id}"
+      end
+
+      # @api private
+      def waiting_group_id
+        tests_repo.find(waiting_result.test_id).parent.id
+      end
+
+      # @api private
+      def call(_params)
+        if test_run.nil?
+          status(500, "Unable to find test run with identifier '#{test_run_identifier}'.")
+          return
+        end
+
+        test_runs_repo.update_status_and_identifier(test_run.id, 'running', nil)
+
+        update_result
+        persist_request
+
+        redirect_to redirect_route
+      end
+    end
+  end
+end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -259,6 +259,16 @@ module Inferno
 
         @validator_url = url
       end
+
+      def suite
+        return self if ancestors.include? Inferno::Entities::TestSuite
+
+        parent.suite
+      end
+
+      def route(method, path, handler)
+        Inferno.routes << { method: method, path: path, handler: handler, suite: suite }
+      end
     end
   end
 end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -1,3 +1,5 @@
+require_relative 'resume_test_route'
+
 module Inferno
   module DSL
     # This module contains the DSL for defining child entities in the test
@@ -243,6 +245,7 @@ module Inferno
         @outputs ||= []
       end
 
+      # @api private
       def child_types
         return [] if ancestors.include? Inferno::Entities::Test
         return [:groups] if ancestors.include? Inferno::Entities::TestSuite
@@ -250,6 +253,7 @@ module Inferno
         [:groups, :tests]
       end
 
+      # @api private
       def children
         @children ||= []
       end
@@ -260,10 +264,20 @@ module Inferno
         @validator_url = url
       end
 
+      # @api private
       def suite
         return self if ancestors.include? Inferno::Entities::TestSuite
 
         parent.suite
+      end
+
+      def resume_test_route(method, path, **options, &block)
+        route_class = Class.new(ResumeTestRoute) do
+          define_method(:test_run_identifier, &block)
+          define_method(:request_name, -> { options[:name] })
+        end
+
+        route(method, path, route_class)
       end
 
       def route(method, path, handler)

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -1,3 +1,4 @@
+require 'pry'
 module Inferno
   module Entities
     # A `Request` represents a request and response issued during a test.
@@ -138,9 +139,7 @@ module Inferno
             url: url,
             direction: 'incoming',
             name: name,
-            # TODO: fix
-            # request_body: rack_request.body.is_a?(::Puma::NullIO) ? nil : rack_request.body,
-            request_body: rack_request.body,
+            request_body: rack_request.body.string,
             headers: request_headers
           )
         end

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -140,7 +140,7 @@ module Inferno
             url: url,
             direction: 'incoming',
             name: name,
-            request_body: rack_request.body,
+            request_body: rack_request.body.is_a?(Puma::NullIO) ? nil : rack_request.body,
             headers: request_headers
           )
         end

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -135,12 +135,15 @@ module Inferno
               .select { |key, _| key.start_with? 'HTTP_' }
               .transform_keys { |key| key.delete_prefix('HTTP_').tr('_', '-').downcase }
               .map { |header_name, value| Header.new(name: header_name, value: value, type: 'request') }
+
           new(
             verb: rack_request.request_method.downcase,
             url: url,
             direction: 'incoming',
             name: name,
-            request_body: rack_request.body.is_a?(Puma::NullIO) ? nil : rack_request.body,
+            # TODO: fix
+            # request_body: rack_request.body.is_a?(::Puma::NullIO) ? nil : rack_request.body,
+            request_body: rack_request.body,
             headers: request_headers
           )
         end

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -36,12 +36,9 @@ module Inferno
         @headers = params[:headers]&.map { |header| header.is_a?(Hash) ? Header.new(header) : header } || []
       end
 
+      # @return [Hash<String, String>]
       def query_parameters
         Addressable::URI.parse(url).query_values || {}
-      end
-
-      def add_response_header(name, value)
-        headers << Header.new(name: name, value: value, type: 'response')
       end
 
       # Find a response header

--- a/lib/inferno/entities/result.rb
+++ b/lib/inferno/entities/result.rb
@@ -44,6 +44,10 @@ module Inferno
       def runnable
         test || test_group || test_suite
       end
+
+      def waiting?
+        result == 'wait'
+      end
     end
   end
 end

--- a/lib/inferno/entities/result.rb
+++ b/lib/inferno/entities/result.rb
@@ -41,10 +41,12 @@ module Inferno
         @requests = (params[:requests] || []).map { |request| Request.new(request) }
       end
 
+      # @return [Inferno::Entities::Test, Inferno::Entities::TestGroup, Inferno::Entities::TestSuite]
       def runnable
         test || test_group || test_suite
       end
 
+      # @return [Boolean]
       def waiting?
         result == 'wait'
       end

--- a/lib/inferno/entities/test_run.rb
+++ b/lib/inferno/entities/test_run.rb
@@ -21,6 +21,7 @@ module Inferno
         :test_suite,
         :inputs,
         :results,
+        :identifier,
         :created_at,
         :updated_at
       ].freeze

--- a/lib/inferno/entities/test_run.rb
+++ b/lib/inferno/entities/test_run.rb
@@ -22,6 +22,7 @@ module Inferno
         :inputs,
         :results,
         :identifier,
+        :wait_timeout,
         :created_at,
         :updated_at
       ].freeze

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -27,6 +27,18 @@ module Inferno
       end
     end
 
+    class WaitException < TestResultException
+      def result
+        'wait'
+      end
+    end
+
+    class CancelException < TestResultException
+      def result
+        'cancel'
+      end
+    end
+
     class ParentNotLoadedException < RuntimeError
       def initialize(klass, id)
         super("No #{klass.name.demodulize} found with id '#{id}'")

--- a/lib/inferno/repositories/repository.rb
+++ b/lib/inferno/repositories/repository.rb
@@ -80,6 +80,19 @@ module Inferno
         build_entity(result.to_hash.merge(handle_non_db_params(params)))
       end
 
+      # Update a record in the database.
+      #
+      # @param entity_id [String]
+      # @param params [Hash]
+      # @example
+      #   repo = Inferno::Repositories::SomeEntities.new
+      #   result = repo.update(id, key1: 'value1', key2: 'value2')
+      def update(entity_id, params = {})
+        self.class::Model
+          .find(id: entity_id)
+          .update(params.merge(updated_at: Time.now))
+      end
+
       # Creates an instance of the entity associated with this repository.
       # Override if any special logic is required to create the entity.
       #

--- a/lib/inferno/repositories/results.rb
+++ b/lib/inferno/repositories/results.rb
@@ -37,20 +37,22 @@ module Inferno
       def find_waiting_result(test_run_id:)
         result_hash =
           Model
-            .where(test_run_id: test_run_id, status: 'waiting')
+            .where(test_run_id: test_run_id, result: 'wait')
             .where { test_id !~ nil }
-            .one
-            .to_hash
+            .limit(1)
+            .to_a
+            .first
+            &.to_hash
 
         return nil if result_hash.nil?
 
         build_entity(result_hash)
       end
 
-      def update_result(result_id, result)
+      def update_result_and_message(result_id, result, message)
         self.class::Model
           .find(id: result_id)
-          .update(result: result, updated_at: Time.now)
+          .update(result: result, result_message: message, updated_at: Time.now)
       end
 
       def json_serializer_options

--- a/lib/inferno/repositories/results.rb
+++ b/lib/inferno/repositories/results.rb
@@ -34,6 +34,25 @@ module Inferno
         entity_class.new(params.merge(runnable))
       end
 
+      def find_waiting_result(test_run_id:)
+        result_hash =
+          Model
+            .where(test_run_id: test_run_id, status: 'waiting')
+            .where { test_id !~ nil }
+            .one
+            .to_hash
+
+        return nil if result_hash.nil?
+
+        build_entity(result_hash)
+      end
+
+      def update_result(result_id, result)
+        self.class::Model
+          .find(id: result_id)
+          .update(result: result, updated_at: Time.now)
+      end
+
       def json_serializer_options
         {
           include: {

--- a/lib/inferno/repositories/results.rb
+++ b/lib/inferno/repositories/results.rb
@@ -49,10 +49,8 @@ module Inferno
         build_entity(result_hash)
       end
 
-      def update_result_and_message(result_id, result, message)
-        self.class::Model
-          .find(id: result_id)
-          .update(result: result, result_message: message, updated_at: Time.now)
+      def pass_waiting_result(result_id, message = nil)
+        update(result_id, result: 'pass', result_message: message)
       end
 
       def json_serializer_options

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -24,10 +24,9 @@ module Inferno
           .map! { |result| results_repo.build_entity(result) }
       end
 
-      def find_latest_waiting_by_suite_and_identifier(test_suite_id:, identifier:)
+      def find_latest_waiting_by_identifier(identifier)
         test_run_hash =
           self.class::Model
-            .where(test_suite_id: test_suite_id)
             .where(status: 'wait')
             .where(identifier: identifier)
             .order(Sequel.desc(:updated_at))
@@ -38,13 +37,25 @@ module Inferno
 
         return nil if test_run_hash.nil?
 
-        results_repo.build_entity(test_run_hash)
+        build_entity(test_run_hash)
       end
 
-      def update_status_and_clear_identifier(_test_run_id, status)
+      def update_identifier(test_run_id, identifier)
         self.class::Model
-          .find(id: test_test_run_id)
-          .update(status: status, identifier: nil, updated_at: Time.now)
+          .find(id: test_run_id)
+          .update(identifier: identifier, updated_at: Time.now)
+      end
+
+      def update_status(test_run_id, status)
+        self.class::Model
+          .find(id: test_run_id)
+          .update(status: status, updated_at: Time.now)
+      end
+
+      def update_status_and_identifier(test_run_id, status, identifier)
+        self.class::Model
+          .find(id: test_run_id)
+          .update(status: status, identifier: identifier, updated_at: Time.now)
       end
 
       class Model < Sequel::Model(db)

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -40,22 +40,24 @@ module Inferno
         build_entity(test_run_hash)
       end
 
-      def update_identifier(test_run_id, identifier)
-        self.class::Model
-          .find(id: test_run_id)
-          .update(identifier: identifier, updated_at: Time.now)
+      def clear_identifier(test_run_id)
+        update(test_run_id, identifier: nil)
       end
 
-      def update_status(test_run_id, status)
-        self.class::Model
-          .find(id: test_run_id)
-          .update(status: status, updated_at: Time.now)
+      def mark_as_running(test_run_id)
+        update(test_run_id, status: 'running')
       end
 
-      def update_status_and_identifier(test_run_id, status, identifier)
-        self.class::Model
-          .find(id: test_run_id)
-          .update(status: status, identifier: identifier, updated_at: Time.now)
+      def mark_as_done(test_run_id)
+        update(test_run_id, status: 'done')
+      end
+
+      def mark_as_waiting(test_run_id, identifier)
+        update(
+          test_run_id,
+          status: 'waiting',
+          identifier: identifier
+        )
       end
 
       class Model < Sequel::Model(db)

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -24,6 +24,27 @@ module Inferno
           .map! { |result| results_repo.build_entity(result) }
       end
 
+      def find_latest_waiting_by_suite_and_input(test_suite_id:, input_name:, input_value:)
+        test_run_hash =
+          self.class::Model
+            .where(test_suite_id: test_suite_id)
+            .where(status: 'wait')
+            .join(TestRunInput.where(name: input_name, value: input_value))
+            .order(Sequel.desc(:updated_at))
+            .limit(1)
+            .to_a
+            &.first
+            &.to_hash
+
+        return nil if test_run_hash.nil?
+
+        results_repo.build_entity(test_run_hash)
+      end
+
+      def update_test_run_status(test_run_id, status)
+
+      end
+
       class Model < Sequel::Model(db)
         include ValidateRunnableReference
 

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -27,7 +27,7 @@ module Inferno
       def find_latest_waiting_by_identifier(identifier)
         test_run_hash =
           self.class::Model
-            .where(status: 'wait')
+            .where(status: 'waiting')
             .where(identifier: identifier)
             .where { wait_timeout >= Time.now }
             .order(Sequel.desc(:updated_at))
@@ -61,7 +61,7 @@ module Inferno
       def mark_as_no_longer_waiting(test_run_id)
         update(
           test_run_id,
-          status: 'paised',
+          status: 'paused',
           identifier: nil,
           wait_timeout: nil
         )

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -24,12 +24,12 @@ module Inferno
           .map! { |result| results_repo.build_entity(result) }
       end
 
-      def find_latest_waiting_by_suite_and_input(test_suite_id:, input_name:, input_value:)
+      def find_latest_waiting_by_suite_and_identifier(test_suite_id:, identifier:)
         test_run_hash =
           self.class::Model
             .where(test_suite_id: test_suite_id)
             .where(status: 'wait')
-            .join(TestRunInput.where(name: input_name, value: input_value))
+            .where(identifier: identifier)
             .order(Sequel.desc(:updated_at))
             .limit(1)
             .to_a
@@ -41,8 +41,10 @@ module Inferno
         results_repo.build_entity(test_run_hash)
       end
 
-      def update_test_run_status(test_run_id, status)
-
+      def update_status_and_clear_identifier(_test_run_id, status)
+        self.class::Model
+          .find(id: test_test_run_id)
+          .update(status: status, identifier: nil, updated_at: Time.now)
       end
 
       class Model < Sequel::Model(db)

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -29,6 +29,7 @@ module Inferno
           self.class::Model
             .where(status: 'wait')
             .where(identifier: identifier)
+            .where { wait_timeout >= Time.now }
             .order(Sequel.desc(:updated_at))
             .limit(1)
             .to_a
@@ -40,10 +41,6 @@ module Inferno
         build_entity(test_run_hash)
       end
 
-      def clear_identifier(test_run_id)
-        update(test_run_id, identifier: nil)
-      end
-
       def mark_as_running(test_run_id)
         update(test_run_id, status: 'running')
       end
@@ -52,11 +49,21 @@ module Inferno
         update(test_run_id, status: 'done')
       end
 
-      def mark_as_waiting(test_run_id, identifier)
+      def mark_as_waiting(test_run_id, identifier, timeout)
         update(
           test_run_id,
           status: 'waiting',
-          identifier: identifier
+          identifier: identifier,
+          wait_timeout: Time.now + timeout.seconds
+        )
+      end
+
+      def mark_as_no_longer_waiting(test_run_id)
+        update(
+          test_run_id,
+          status: 'paised',
+          identifier: nil,
+          wait_timeout: nil
         )
       end
 

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -42,6 +42,10 @@ module Inferno
         outputs[output] = test_instance.send(output)
       end
 
+      if result == 'wait'
+        Inferno::Repositories::TestRuns.new.update_status_and_identifier(test_run.id, 'wait', test_instance.identifier)
+      end
+
       [persist_result(
         {
           test_session_id: test_session.id,

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -55,7 +55,14 @@ module Inferno
     end
 
     def run_group(runnable, inputs = {}, outputs = {})
-      results = runnable.children.flat_map { |child| run(child, inputs, outputs) }
+      results = []
+      runnable.children.each do |child|
+        result = run(child, inputs, outputs)
+        results << result
+        break if result.last.waiting?
+      end
+
+      results.flatten!
 
       results << persist_result(
         {

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -17,10 +17,10 @@ module Inferno
     end
 
     def start(runnable, inputs = {}, outputs = {})
-      test_runs_repo.update_status(test_run.id, 'running')
+      test_runs_repo.mark_as_running(test_run.id)
 
       run(runnable, inputs, outputs).tap do |results|
-        test_runs_repo.update_status(test_run.id, 'done') unless results.any?(&:waiting?)
+        test_runs_repo.mark_as_done(test_run.id) unless results.any?(&:waiting?)
       end
     end
 
@@ -55,7 +55,7 @@ module Inferno
         outputs[output] = test_instance.send(output)
       end
 
-      test_runs_repo.update_status_and_identifier(test_run.id, 'wait', test_instance.identifier) if result == 'wait'
+      test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier) if result == 'wait'
 
       [persist_result(
         {

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -55,7 +55,9 @@ module Inferno
         outputs[output] = test_instance.send(output)
       end
 
-      test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier) if result == 'wait'
+      if result == 'wait'
+        test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier, test_instance.wait_timeout)
+      end
 
       [persist_result(
         {

--- a/spec/factories/test_run.rb
+++ b/spec/factories/test_run.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     test_id { runnable[:test_id] }
 
     inputs { nil }
+    wait_timeout { nil }
 
     initialize_with { new(**attributes) }
 

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Inferno::DSL::Runnable do
         test_session_id: test_session.id,
         runnable: { test_group_id: test_group.id },
         identifier: 'IDENTIFIER',
-        status: 'wait',
+        status: 'waiting',
         wait_timeout: Time.now + 300.seconds
       )
     end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -1,0 +1,68 @@
+require 'request_helper'
+
+RSpec.describe Inferno::DSL::Runnable do
+  include Rack::Test::Methods
+  include RequestHelpers
+
+  describe '.resume_test_route' do
+    let(:test_suite) { Inferno::Repositories::TestSuites.new.find('demo') }
+    let(:test_group) { Inferno::Repositories::TestGroups.new.find('demo-wait_group') }
+    let(:wait_test) { test_group.tests[1] }
+    let(:test_session) { repo_create(:test_session, test_suite_id: test_suite.id) }
+    let!(:test_run) do
+      repo_create(
+        :test_run,
+        test_session_id: test_session.id,
+        runnable: { test_group_id: test_group.id },
+        identifier: 'IDENTIFIER',
+        status: 'wait'
+      )
+    end
+
+    let!(:result) do
+      repo_create(
+        :result,
+        test_run_id: test_run.id,
+        runnable: wait_test.reference_hash,
+        result_message: 'waiting for incoming request',
+        result: 'wait'
+      )
+    end
+
+    context 'when the identifier does not match a test run' do
+      it 'renders a 500 error' do
+        get '/custom/demo/resume?xyz=BAD_IDENTIFIER'
+        expect(last_response.status).to eq(500)
+      end
+    end
+
+    context 'when the identifier does match a test run' do
+      it 'redirects the user to the waiting group' do
+        get '/custom/demo/resume?xyz=IDENTIFIER'
+
+        expect(last_response.status).to eq(302)
+
+        location_header = last_response.get_header('location')
+
+        expect(location_header).to eq("/test_sessions/#{test_session.id}##{test_group.id}")
+      end
+
+      it 'updates the waiting test result' do
+        get '/custom/demo/resume?xyz=IDENTIFIER'
+
+        updated_result = Inferno::Repositories::Results.new.find(result.id)
+
+        expect(updated_result.result).to eq('pass')
+        expect(updated_result.result_message).to be_nil
+      end
+
+      it 'updates the waiting test run' do
+        get '/custom/demo/resume?xyz=IDENTIFIER'
+
+        updated_run = Inferno::Repositories::TestRuns.new.find(test_run.id)
+
+        expect(updated_run.identifier).to be_nil
+      end
+    end
+  end
+end

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -2,7 +2,7 @@
 #   refactor.
 RSpec.describe Inferno::TestRunner do
   let(:runner) { described_class.new(test_session: test_session, test_run: test_run) }
-  let(:test_session) { repo_create(:test_session, test_suite_id: 'DemoIG_STU1::DemoSuite') }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'demo') }
   let(:test_run) do
     repo_create(:test_run, runnable: { test_group_id: group.id }, test_session_id: test_session.id)
   end
@@ -16,7 +16,7 @@ RSpec.describe Inferno::TestRunner do
   describe 'when running demo group' do
     let(:base_url) { 'http://hapi.fhir.org/baseR4' }
     let(:patient_id) { 1215072 }
-    let(:group) { Inferno::Repositories::TestSuites.new.find('DemoIG_STU1::DemoSuite').groups.first.groups.first }
+    let(:group) { Inferno::Repositories::TestSuites.new.find('demo').groups.first.groups.first }
     let(:patient) { FHIR::Patient.new(id: patient_id) }
     let(:observation_bundle) do
       FHIR::Bundle.new(
@@ -68,7 +68,7 @@ RSpec.describe Inferno::TestRunner do
   end
 
   describe 'when running wait group' do
-    let(:group) { Inferno::Repositories::TestSuites.new.find('DemoIG_STU1::DemoSuite').groups.last }
+    let(:group) { Inferno::Repositories::TestSuites.new.find('demo').groups.last }
 
     it 'gives a wait result' do
       results = runner.run(group, {})

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -1,36 +1,10 @@
 # NOTE: These are basic placeholder specs to make sure we don't break this as we
 #   refactor.
 RSpec.describe Inferno::TestRunner do
-  let(:base_url) { 'http://hapi.fhir.org/baseR4' }
-  let(:patient_id) { 1215072 }
-  let(:group) { Inferno::Repositories::TestSuites.new.find('DemoIG_STU1::DemoSuite').groups.first.groups.first }
   let(:runner) { described_class.new(test_session: test_session, test_run: test_run) }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'DemoIG_STU1::DemoSuite') }
   let(:test_run) do
     repo_create(:test_run, runnable: { test_group_id: group.id }, test_session_id: test_session.id)
-  end
-  let(:patient) { FHIR::Patient.new(id: patient_id) }
-  let(:observation_bundle) do
-    FHIR::Bundle.new(
-      entry: [
-        {
-          resource: FHIR::Observation.new(id: 123)
-        }
-      ]
-    )
-  end
-
-  before do
-    stub_request(:get, "#{base_url}/Patient/#{patient_id}")
-      .to_return(status: 200, body: patient.to_json)
-    stub_request(:get, "#{base_url}/Observation")
-      .with(query: { 'patient' => patient_id })
-      .to_return(status: 200, body: observation_bundle.to_json)
-    stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
-      .with(query: hash_including({}))
-      .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
-    stub_request(:get, 'http://example.com')
-      .to_return(status: 200)
   end
 
   def error_results_message(error_results)
@@ -39,28 +13,74 @@ RSpec.describe Inferno::TestRunner do
     end.join("\n")
   end
 
-  it 'runs' do
-    expect do
-      runner.run(group, { url: base_url, patient_id: patient_id })
-    end.to_not raise_error
+  describe 'when running demo group' do
+    let(:base_url) { 'http://hapi.fhir.org/baseR4' }
+    let(:patient_id) { 1215072 }
+    let(:group) { Inferno::Repositories::TestSuites.new.find('DemoIG_STU1::DemoSuite').groups.first.groups.first }
+    let(:patient) { FHIR::Patient.new(id: patient_id) }
+    let(:observation_bundle) do
+      FHIR::Bundle.new(
+        entry: [
+          {
+            resource: FHIR::Observation.new(id: 123)
+          }
+        ]
+      )
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/Patient/#{patient_id}")
+        .to_return(status: 200, body: patient.to_json)
+      stub_request(:get, "#{base_url}/Observation")
+        .with(query: { 'patient' => patient_id })
+        .to_return(status: 200, body: observation_bundle.to_json)
+      stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
+      stub_request(:get, 'http://example.com')
+        .to_return(status: 200)
+    end
+
+    it 'runs' do
+      expect do
+        runner.run(group, { url: base_url, patient_id: patient_id })
+      end.to_not raise_error
+    end
+
+    it 'creates results' do
+      test_count = group.tests.length
+
+      results = runner.run(group, { url: base_url, patient_id: patient_id })
+
+      expect(results.length).to eq(test_count + 1)
+    end
+
+    it 'only contains no "error" results apart from the "error test"' do
+      results = runner.run(group, { url: base_url, patient_id: patient_id })
+      error_results =
+        results
+          .reject { |result| result.test&.title == 'error test' }
+          .reject { |result| result.test_group&.title == 'Demo Group Instance 1' }
+          .select { |result| result.result == 'error' }
+
+      expect(error_results).to be_empty, error_results_message(error_results)
+    end
   end
 
-  it 'creates results' do
-    test_count = group.tests.length
+  describe 'when running wait group' do
+    let(:group) { Inferno::Repositories::TestSuites.new.find('DemoIG_STU1::DemoSuite').groups.last }
 
-    results = runner.run(group, { url: base_url, patient_id: patient_id })
+    it 'gives a wait result' do
+      results = runner.run(group, {})
+      group_result = results.find { |result| result.test_group_id.present? }
 
-    expect(results.length).to eq(test_count + 1)
-  end
+      expect(group_result.result).to eq('wait')
+    end
 
-  it 'only contains no "error" results apart from the "error test"' do
-    results = runner.run(group, { url: base_url, patient_id: patient_id })
-    error_results =
-      results
-        .reject { |result| result.test&.title == 'error test' }
-        .reject { |result| result.test_group&.title == 'Demo Group Instance 1' }
-        .select { |result| result.result == 'error' }
+    it 'does not run the last test' do
+      results = runner.run(group, {})
 
-    expect(error_results).to be_empty, error_results_message(error_results)
+      expect(results.length).to eq(3)
+    end
   end
 end


### PR DESCRIPTION
This branch allows a test to return a `wait` result, which waits until an incoming request is received. When calling `wait`, an identifier must be provided to allow this test run to be identified in the incoming request. Routes can also be defined to resume test execution with `resume_test_route`, which takes an HTTP verb, a path, and a block which returns an identifier based on the incoming request.

The (placeholder) SMART suite included in this PR demonstrates this functionality. To see it in action, run the SMART tests, then navigate to `/custom/smart/launch?iss=abc`. That should redirect you back to the tests, where you can run the next test, which is able to access the details of the earlier incoming request.

It is also possible to just serve plain routes using any rack-compatible object (anything from a `Proc` to an entire Sinatra app).

Things that still need to be done in other tickets:
- Update the test runner to allow resuming (will require persisting inputs & outputs)
- Make test running asynchronous
- Make routes shareable
- Make some sort of abstraction for prompting the user