### PR TITLE
fix request url from pushing out buttons and change inputs label style

### DIFF
--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -66,6 +66,7 @@ const InputsModal: FC<InputsModalProps> = ({
           <ListItem key={`requirement${index}`}>
             <TextField
               id={`requirement${index}_input`}
+              className={styles.inputField}
               fullWidth
               label={requirement.title || requirement.name}
               helperText={requirement.description}
@@ -86,6 +87,7 @@ const InputsModal: FC<InputsModalProps> = ({
           <ListItem key={`requirement${index}`}>
             <TextField
               id={`requirement${index}_input`}
+              className={styles.inputField}
               fullWidth
               label={requirement.title || requirement.name}
               helperText={requirement.description}

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -7,7 +7,7 @@ export default makeStyles((_theme: Theme) => ({
     overflow: 'auto !important',
   },
   inputField: {
-    '& > label': {
+    '& > label.MuiInputLabel-shrink': {
       fontWeight: 600,
       color: 'rgba(0,0,0,0.85)',
     },

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -6,4 +6,10 @@ export default makeStyles((_theme: Theme) => ({
     maxHeight: '400px',
     overflow: 'auto !important',
   },
+  inputField: {
+    '& > label': {
+      fontWeight: 600,
+      color: 'rgba(0,0,0,0.85)',
+    },
+  },
 }));

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -1,8 +1,9 @@
 import React, { FC, Fragment } from 'react';
-import { Table, TableBody, TableRow, TableCell, Button } from '@material-ui/core';
+import { Button, Box } from '@material-ui/core';
 import { Request } from 'models/testSuiteModels';
 import RequestDetailModal from 'components/RequestDetailModal/RequestDetailModal';
 import { getRequestDetails } from 'api/RequestsApi';
+import useStyles from './styles';
 
 interface RequestsListProps {
   resultId: string;
@@ -13,6 +14,7 @@ interface RequestsListProps {
 const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest }) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const [detailedRequest, setDetailedRequest] = React.useState<Request>();
+  const styles = useStyles();
 
   function showDetailsClick(request: Request) {
     if (request.request_headers == null) {
@@ -39,14 +41,16 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
     requests.length > 0 ? (
       requests.map((request: Request, index: number) => {
         return (
-          <TableRow key={`msgRow-${index}`}>
-            <TableCell>
+          <Box key={`reqRow-${index}`} className={styles.requestRow}>
+            <Box>
               <span>{request.direction}</span>
-            </TableCell>
-            <TableCell>{request.verb}</TableCell>
-            <TableCell>{request.url}</TableCell>
-            <TableCell>{request.status}</TableCell>
-            <TableCell>
+            </Box>
+            <Box>{request.verb}</Box>
+            <Box className={styles.requestUrl}>
+              <Box>{request.url}</Box>
+            </Box>
+            <Box>{request.status}</Box>
+            <Box>
               <Button
                 onClick={() => showDetailsClick(request)}
                 variant="contained"
@@ -55,21 +59,17 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
               >
                 Details
               </Button>
-            </TableCell>
-          </TableRow>
+            </Box>
+          </Box>
         );
       })
     ) : (
-      <TableRow key={`msgRow-none`}>
-        <TableCell>None</TableCell>
-      </TableRow>
+      <Box>None</Box>
     );
 
   return (
     <Fragment>
-      <Table>
-        <TableBody>{requestListItems}</TableBody>
-      </Table>
+      {requestListItems}
       <RequestDetailModal
         request={detailedRequest}
         modalVisible={showDetails}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
@@ -39,4 +39,29 @@ export default makeStyles((theme: Theme) => ({
     marginBottom: '15px',
     color: 'rgba(0,0,0,0.6)',
   },
+  requestRowItem: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  requestRow: {
+    display: 'flex',
+    textAlign: 'center',
+    height: '45px',
+    '& > *': {
+      display: 'flex',
+      alignItems: 'center',
+      margin: '10px',
+    },
+  },
+  requestUrl: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    flexGrow: 1,
+    '& > *': {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
+  },
 }));


### PR DESCRIPTION
This PR makes it so really long url's don't cut off the rest of the request row. 
![image](https://user-images.githubusercontent.com/45495440/129733421-fa5f7f6a-7ff3-4723-a9b2-6c754734e340.png)

I also made the input labels bold and darker to differentiate it from the helper text
![image](https://user-images.githubusercontent.com/45495440/129733577-b11aff7a-1df0-4fe3-8626-ed57d0de6330.png)
