### PR TITLE
Fi 1311 add input require optional

### DIFF
--- a/client/src/api/TestRunsApi.ts
+++ b/client/src/api/TestRunsApi.ts
@@ -14,7 +14,7 @@ export function postTestRun(
   runnableType: RunnableType,
   runnableId: string,
   inputs: TestInput[]
-): Promise<TestRun> {
+): Promise<TestRun | null> {
   const postEndpoint = getEndpoint('/test_runs');
   const postBody: CreateTestRunBody = {
     test_session_id: testSessionId,
@@ -44,7 +44,7 @@ export function postTestRun(
     })
     .catch((e) => {
       console.log(e);
-      return { id: 'error', testSessionId: testSessionId };
+      return null;
     });
 }
 

--- a/client/src/components/InputsModal/InputTextArea.tsx
+++ b/client/src/components/InputsModal/InputTextArea.tsx
@@ -1,0 +1,50 @@
+import { InputAdornment, ListItem, TextField, Zoom } from '@material-ui/core';
+import { TestInput } from 'models/testSuiteModels';
+import React, { FC } from 'react';
+import RequiredInputWarning from './RequiredInputWarning';
+import useStyles from './styles';
+
+export interface InputTextAreaProps {
+  requirement: TestInput;
+  index: number;
+  inputsMap: Map<string, string>;
+  setInputsMap: (map: Map<string, string>) => void;
+}
+
+const InputTextArea: FC<InputTextAreaProps> = ({ requirement, index, inputsMap, setInputsMap }) => {
+  const value = inputsMap.get(requirement.name);
+  const styles = useStyles();
+  const missingRequired = !requirement.optional && value?.length == 0;
+  const requiredWarning = (
+    <Zoom in={missingRequired}>
+      <InputAdornment position="end">
+        <RequiredInputWarning />
+      </InputAdornment>
+    </Zoom>
+  );
+  return (
+    <ListItem key={`requirement${index}`}>
+      <TextField
+        id={`requirement${index}_input`}
+        className={styles.inputField}
+        fullWidth
+        label={requirement.title || requirement.name}
+        helperText={requirement.description}
+        value={inputsMap.get(requirement.name)}
+        multiline
+        rows={4}
+        InputProps={{
+          className: styles.textarea,
+          endAdornment: requiredWarning,
+        }}
+        onChange={(event) => {
+          const value = event.target.value;
+          inputsMap.set(requirement.name, value);
+          setInputsMap(new Map(inputsMap));
+        }}
+      />
+    </ListItem>
+  );
+};
+
+export default InputTextArea;

--- a/client/src/components/InputsModal/InputTextArea.tsx
+++ b/client/src/components/InputsModal/InputTextArea.tsx
@@ -1,7 +1,6 @@
-import { InputAdornment, ListItem, TextField, Zoom } from '@material-ui/core';
+import { ListItem, TextField } from '@material-ui/core';
 import { TestInput } from 'models/testSuiteModels';
-import React, { FC } from 'react';
-import RequiredInputWarning from './RequiredInputWarning';
+import React, { FC, Fragment } from 'react';
 import useStyles from './styles';
 
 export interface InputTextAreaProps {
@@ -12,31 +11,26 @@ export interface InputTextAreaProps {
 }
 
 const InputTextArea: FC<InputTextAreaProps> = ({ requirement, index, inputsMap, setInputsMap }) => {
-  const value = inputsMap.get(requirement.name);
   const styles = useStyles();
-  const missingRequired = !requirement.optional && value?.length == 0;
-  const requiredWarning = (
-    <Zoom in={missingRequired}>
-      <InputAdornment position="end">
-        <RequiredInputWarning />
-      </InputAdornment>
-    </Zoom>
+  const fieldLabel = requirement.optional ? (
+    requirement.title || requirement.name
+  ) : (
+    <Fragment>
+      {requirement.title || requirement.name}
+      <span className={styles.requiredLabel}> (required)</span>
+    </Fragment>
   );
   return (
-    <ListItem key={`requirement${index}`}>
+    <ListItem>
       <TextField
         id={`requirement${index}_input`}
         className={styles.inputField}
         fullWidth
-        label={requirement.title || requirement.name}
+        label={fieldLabel}
         helperText={requirement.description}
         value={inputsMap.get(requirement.name)}
         multiline
         rows={4}
-        InputProps={{
-          className: styles.textarea,
-          endAdornment: requiredWarning,
-        }}
         onChange={(event) => {
           const value = event.target.value;
           inputsMap.set(requirement.name, value);

--- a/client/src/components/InputsModal/InputTextField.tsx
+++ b/client/src/components/InputsModal/InputTextField.tsx
@@ -1,7 +1,6 @@
-import { InputAdornment, ListItem, TextField, Zoom } from '@material-ui/core';
+import { ListItem, TextField } from '@material-ui/core';
 import { TestInput } from 'models/testSuiteModels';
-import RequiredInputWarning from './RequiredInputWarning';
-import React, { FC } from 'react';
+import React, { FC, Fragment } from 'react';
 import useStyles from './styles';
 
 export interface InputTextFieldProps {
@@ -17,28 +16,24 @@ const InputTextField: FC<InputTextFieldProps> = ({
   inputsMap,
   setInputsMap,
 }) => {
-  const value = inputsMap.get(requirement.name);
   const styles = useStyles();
-  const missingRequired = !requirement.optional && value?.length == 0;
-  const requiredWarning = (
-    <Zoom in={missingRequired}>
-      <InputAdornment position="end">
-        <RequiredInputWarning />
-      </InputAdornment>
-    </Zoom>
+  const fieldLabel = requirement.optional ? (
+    requirement.title || requirement.name
+  ) : (
+    <Fragment>
+      {requirement.title || requirement.name}
+      <span className={styles.requiredLabel}> (required)</span>
+    </Fragment>
   );
   return (
-    <ListItem key={`requirement${index}`}>
+    <ListItem>
       <TextField
         id={`requirement${index}_input`}
         className={styles.inputField}
         fullWidth
-        label={requirement.title || requirement.name}
+        label={fieldLabel}
         helperText={requirement.description}
         value={inputsMap.get(requirement.name)}
-        InputProps={{
-          endAdornment: requiredWarning,
-        }}
         onChange={(event) => {
           const value = event.target.value;
           inputsMap.set(requirement.name, value);

--- a/client/src/components/InputsModal/InputTextField.tsx
+++ b/client/src/components/InputsModal/InputTextField.tsx
@@ -1,0 +1,52 @@
+import { InputAdornment, ListItem, TextField, Zoom } from '@material-ui/core';
+import { TestInput } from 'models/testSuiteModels';
+import RequiredInputWarning from './RequiredInputWarning';
+import React, { FC } from 'react';
+import useStyles from './styles';
+
+export interface InputTextFieldProps {
+  requirement: TestInput;
+  index: number;
+  inputsMap: Map<string, string>;
+  setInputsMap: (map: Map<string, string>) => void;
+}
+
+const InputTextField: FC<InputTextFieldProps> = ({
+  requirement,
+  index,
+  inputsMap,
+  setInputsMap,
+}) => {
+  const value = inputsMap.get(requirement.name);
+  const styles = useStyles();
+  const missingRequired = !requirement.optional && value?.length == 0;
+  const requiredWarning = (
+    <Zoom in={missingRequired}>
+      <InputAdornment position="end">
+        <RequiredInputWarning />
+      </InputAdornment>
+    </Zoom>
+  );
+  return (
+    <ListItem key={`requirement${index}`}>
+      <TextField
+        id={`requirement${index}_input`}
+        className={styles.inputField}
+        fullWidth
+        label={requirement.title || requirement.name}
+        helperText={requirement.description}
+        value={inputsMap.get(requirement.name)}
+        InputProps={{
+          endAdornment: requiredWarning,
+        }}
+        onChange={(event) => {
+          const value = event.target.value;
+          inputsMap.set(requirement.name, value);
+          setInputsMap(new Map(inputsMap));
+        }}
+      />
+    </ListItem>
+  );
+};
+
+export default InputTextField;

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -6,12 +6,11 @@ import {
   DialogContentText,
   DialogTitle,
   List,
-  ListItem,
-  TextField,
 } from '@material-ui/core';
 import { RunnableType, TestInput } from 'models/testSuiteModels';
 import React, { FC, useEffect } from 'react';
-import useStyles from './styles';
+import InputTextArea from './InputTextArea';
+import InputTextField from './InputTextField';
 
 export interface InputsModalProps {
   runnableType: RunnableType;
@@ -41,6 +40,10 @@ const InputsModal: FC<InputsModalProps> = ({
   hideModal,
   createTestRun,
 }) => {
+  const [inputsMap, setInputsMap] = React.useState<Map<string, string>>(new Map());
+  const missingRequiredInput = inputs.some((input: TestInput) => {
+    return !input.optional && inputsMap.get(input.name)?.length == 0;
+  });
   function submitClicked(): void {
     const inputs_with_values: TestInput[] = [];
     inputsMap.forEach((input_value, input_name) => {
@@ -49,8 +52,7 @@ const InputsModal: FC<InputsModalProps> = ({
     createTestRun(runnableType, runnableId, inputs_with_values);
     hideModal();
   }
-  const styles = useStyles();
-  const [inputsMap, setInputsMap] = React.useState<Map<string, string>>(new Map());
+
   useEffect(() => {
     inputsMap.clear();
     inputs.forEach((requirement: TestInput) => {
@@ -63,42 +65,21 @@ const InputsModal: FC<InputsModalProps> = ({
     switch (requirement.type) {
       case 'textarea':
         return (
-          <ListItem key={`requirement${index}`}>
-            <TextField
-              id={`requirement${index}_input`}
-              className={styles.inputField}
-              fullWidth
-              label={requirement.title || requirement.name}
-              helperText={requirement.description}
-              value={inputsMap.get(requirement.name)}
-              multiline
-              rows={4}
-              inputProps={{ className: styles.textarea }}
-              onChange={(event) => {
-                const value = event.target.value;
-                inputsMap.set(requirement.name, value);
-                setInputsMap(new Map(inputsMap));
-              }}
-            />
-          </ListItem>
+          <InputTextArea
+            requirement={requirement}
+            index={index}
+            inputsMap={inputsMap}
+            setInputsMap={setInputsMap}
+          />
         );
       default:
         return (
-          <ListItem key={`requirement${index}`}>
-            <TextField
-              id={`requirement${index}_input`}
-              className={styles.inputField}
-              fullWidth
-              label={requirement.title || requirement.name}
-              helperText={requirement.description}
-              value={inputsMap.get(requirement.name)}
-              onChange={(event) => {
-                const value = event.target.value;
-                inputsMap.set(requirement.name, value);
-                setInputsMap(new Map(inputsMap));
-              }}
-            />
-          </ListItem>
+          <InputTextField
+            requirement={requirement}
+            index={index}
+            inputsMap={inputsMap}
+            setInputsMap={setInputsMap}
+          />
         );
     }
   });
@@ -115,7 +96,7 @@ const InputsModal: FC<InputsModalProps> = ({
         <Button color="primary" onClick={() => hideModal()} data-testid="cancel-button">
           Cancel
         </Button>
-        <Button color="primary" onClick={() => submitClicked()}>
+        <Button color="primary" onClick={() => submitClicked()} disabled={missingRequiredInput}>
           Submit
         </Button>
       </DialogActions>

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -70,6 +70,7 @@ const InputsModal: FC<InputsModalProps> = ({
             index={index}
             inputsMap={inputsMap}
             setInputsMap={setInputsMap}
+            key={`input-${index}`}
           />
         );
       default:
@@ -79,6 +80,7 @@ const InputsModal: FC<InputsModalProps> = ({
             index={index}
             inputsMap={inputsMap}
             setInputsMap={setInputsMap}
+            key={`input-${index}`}
           />
         );
     }

--- a/client/src/components/InputsModal/RequiredInputWarning.tsx
+++ b/client/src/components/InputsModal/RequiredInputWarning.tsx
@@ -1,0 +1,13 @@
+import { Tooltip } from '@material-ui/core';
+import React, { FC } from 'react';
+import WarningIcon from '@material-ui/icons/Warning';
+
+const RequiredInputWarning: FC = () => {
+  return (
+    <Tooltip title="Missing value for required input">
+      <WarningIcon />
+    </Tooltip>
+  );
+};
+
+export default RequiredInputWarning;

--- a/client/src/components/InputsModal/__tests__/InputModal.test.tsx
+++ b/client/src/components/InputsModal/__tests__/InputModal.test.tsx
@@ -10,6 +10,7 @@ const testInputs: TestInput[] = [
   },
   {
     name: 'some other input',
+    optional: true,
   },
   {
     name: 'yet another input',
@@ -45,8 +46,13 @@ test('Modal visible and inputs are shown', () => {
   const titleText = screen.getByText('Test Inputs');
   expect(titleText).toBeVisible();
   testInputs.forEach((input: TestInput) => {
-    const inputField = screen.getByLabelText(input.name);
-    expect(inputField).toBeVisible();
+    if (input.optional) {
+      const inputField = screen.getByLabelText(input.name);
+      expect(inputField).toBeVisible();
+    } else {
+      const inputField = screen.getByLabelText(input.name + ' (required)');
+      expect(inputField).toBeVisible();
+    }
   });
 });
 

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -12,4 +12,9 @@ export default makeStyles((_theme: Theme) => ({
       color: 'rgba(0,0,0,0.85)',
     },
   },
+  requiredLabel: {
+    'label.MuiInputLabel-shrink &': {
+      display: 'none',
+    },
+  },
 }));

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -18,7 +18,7 @@ import TestSuiteTreeComponent from './TestSuiteTree/TestSuiteTree';
 import TestSuiteDetailsPanel from './TestSuiteDetails/TestSuiteDetailsPanel';
 import { getAllContainedInputs } from './TestSuiteUtilities';
 import { useLocation } from 'react-router-dom';
-import { getTestRunWithResults, postTestRun, ErrorResult } from 'api/TestRunsApi';
+import { getTestRunWithResults, postTestRun } from 'api/TestRunsApi';
 
 function mapRunnableRecursive(
   testGroup: TestGroup,
@@ -210,10 +210,12 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     });
     setSessionData(new Map(sessionData));
     postTestRun(id, runnableType, runnableId, inputs)
-      .then((testRun: TestRun) => {
-        setTestRun(testRun);
-        setShowProgressBar(true);
-        pollTestRunResults(testRun);
+      .then((testRun: TestRun | null) => {
+        if (testRun) {
+          setTestRun(testRun);
+          setShowProgressBar(true);
+          pollTestRunResults(testRun);
+        }
       })
       .catch((e) => {
         console.log(e);

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -18,7 +18,7 @@ import TestSuiteTreeComponent from './TestSuiteTree/TestSuiteTree';
 import TestSuiteDetailsPanel from './TestSuiteDetails/TestSuiteDetailsPanel';
 import { getAllContainedInputs } from './TestSuiteUtilities';
 import { useLocation } from 'react-router-dom';
-import { getTestRunWithResults, postTestRun } from 'api/TestRunsApi';
+import { getTestRunWithResults, postTestRun, ErrorResult } from 'api/TestRunsApi';
 
 function mapRunnableRecursive(
   testGroup: TestGroup,

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -45,6 +45,7 @@ export interface TestInput {
   type?: 'text' | 'textarea';
   description?: string;
   default?: string;
+  optional?: boolean;
 }
 
 export interface TestOutput {

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -241,7 +241,8 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       input :textarea,
             title: 'Textarea Input Example',
             type: 'textarea',
-            description: 'Insert something like a patient resource json here'
+            description: 'Insert something like a patient resource json here',
+            optional: true
 
       run { info "Received the following 'textarea' variable: '#{textarea}''" }
     end

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -19,9 +19,7 @@ module Inferno
             required_inputs = test_run.runnable.contained_required_inputs.map(&:to_s)
 
             missing_inputs = required_inputs - params[:inputs].map { |input| input[:name] }
-            if missing_inputs.any?
-              raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs
-            end
+            raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs.any?
 
             self.body = serialize(test_run)
 

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -16,13 +16,8 @@ module Inferno
             # if testsession.nil?
 
             test_run = repo.create(create_params(params).merge(status: 'queued'))
-            required_inputs = test_run.runnable.contained_required_inputs.map(&:to_s)
+            missing_inputs = get_missing_inputs(test_run.runnable, params[:inputs])
 
-            if params[:inputs].nil?
-              missing_inputs = required_inputs
-            else
-              missing_inputs = required_inputs - params[:inputs].map { |input| input[:name] }
-            end
             raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs.any?
 
             self.body = serialize(test_run)
@@ -48,6 +43,13 @@ module Inferno
 
           def create_params(params)
             params.to_h.slice(*PARAMS)
+          end
+
+          def get_missing_inputs(runnable, submitted_inputs)
+            required_inputs = runnable.contained_required_inputs.map(&:to_s)
+            submitted_inputs = [] if submitted_inputs.nil?
+
+            required_inputs - submitted_inputs.map { |input| input[:name] }
           end
         end
       end

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -18,7 +18,11 @@ module Inferno
             test_run = repo.create(create_params(params).merge(status: 'queued'))
             required_inputs = test_run.runnable.contained_required_inputs.map(&:to_s)
 
-            missing_inputs = required_inputs - params[:inputs].map { |input| input[:name] }
+            if params[:inputs].nil?
+              missing_inputs = required_inputs
+            else
+              missing_inputs = required_inputs - params[:inputs].map { |input| input[:name] }
+            end
             raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs.any?
 
             self.body = serialize(test_run)

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -16,7 +16,7 @@ module Inferno
             # if testsession.nil?
 
             test_run = repo.create(create_params(params).merge(status: 'queued'))
-            missing_inputs = get_missing_inputs(test_run.runnable, params[:inputs])
+            missing_inputs = test_run.runnable.get_missing_inputs(params[:inputs])
 
             raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs.any?
 
@@ -43,13 +43,6 @@ module Inferno
 
           def create_params(params)
             params.to_h.slice(*PARAMS)
-          end
-
-          def get_missing_inputs(runnable, submitted_inputs)
-            required_inputs = runnable.contained_required_inputs.map(&:to_s)
-            submitted_inputs = [] if submitted_inputs.nil?
-
-            required_inputs - submitted_inputs.map { |input| input[:name] }
           end
         end
       end

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -16,7 +16,7 @@ module Inferno
             # if testsession.nil?
 
             test_run = repo.create(create_params(params).merge(status: 'queued'))
-            missing_inputs = test_run.runnable.get_missing_inputs(params[:inputs])
+            missing_inputs = test_run.runnable.missing_inputs(params[:inputs])
 
             raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs.any?
 

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -359,12 +359,18 @@ module Inferno
 
       def contained_required_inputs(prior_outputs = [])
         required_inputs = inputs.select do |input|
-          (input[:optional].nil? || !input[:optional]) && !prior_outputs.include?(input[:name])
+          !input_definitions[input][:optional] && !prior_outputs.include?(input)
         end
-        required_inputs.map! { |input| input[:name] }
         children_required_inputs = children.map { |child| child.contained_required_inputs(prior_outputs) }.flatten
         prior_outputs.concat(outputs)
         (required_inputs + children_required_inputs).flatten.uniq
+      end
+
+      def get_missing_inputs(submitted_inputs)
+        required_inputs = contained_required_inputs.map(&:to_s)
+        submitted_inputs = [] if submitted_inputs.nil?
+
+        required_inputs - submitted_inputs.map { |input| input[:name] }
       end
     end
   end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -358,9 +358,10 @@ module Inferno
       end
 
       def contained_required_inputs(prior_outputs = [])
-        required_inputs = inputs.select { |input|
-                            (input[:optional].nil? || !input[:optional]) && !prior_outputs.include?(input[:name])
-                          }.map { |input| input[:name] }
+        required_inputs = inputs.select do |input|
+          (input[:optional].nil? || !input[:optional]) && !prior_outputs.include?(input[:name])
+        end
+        required_inputs.map! { |input| input[:name] }
         children_required_inputs = children.map { |child| child.contained_required_inputs(prior_outputs) }.flatten
         prior_outputs.concat(outputs)
         (required_inputs + children_required_inputs).flatten.uniq

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -357,20 +357,19 @@ module Inferno
         @test_count ||= children&.reduce(0) { |sum, child| sum + child.test_count } || 0
       end
 
-      def contained_required_inputs(prior_outputs = [])
+      def required_inputs(prior_outputs = [])
         required_inputs = inputs.select do |input|
           !input_definitions[input][:optional] && !prior_outputs.include?(input)
         end
-        children_required_inputs = children.map { |child| child.contained_required_inputs(prior_outputs) }.flatten
+        children_required_inputs = children.flat_map { |child| child.required_inputs(prior_outputs) }
         prior_outputs.concat(outputs)
         (required_inputs + children_required_inputs).flatten.uniq
       end
 
-      def get_missing_inputs(submitted_inputs)
-        required_inputs = contained_required_inputs.map(&:to_s)
+      def missing_inputs(submitted_inputs)
         submitted_inputs = [] if submitted_inputs.nil?
 
-        required_inputs - submitted_inputs.map { |input| input[:name] }
+        required_inputs.map(&:to_s) - submitted_inputs.map { |input| input[:name] }
       end
     end
   end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -214,12 +214,13 @@ module Inferno
       # @option input_definition [String] :description Description for the input
       # @option input_definition [String] :type text | textarea
       # @option input_definition [String] :default The default value for the input
+      # @option input_definition [Boolean] :optional Set to true to not require input for test execution
       # @return [void]
       # @example
       #   input :patientid, title: 'Patient ID', description: 'The ID of the patient being searched for',
       #                     default: 'default_patient_id'
       # @example
-      #   input :textarea, title: 'Textarea Input Example', type: 'textarea'
+      #   input :textarea, title: 'Textarea Input Example', type: 'textarea', optional: true
       def input(identifier, *other_identifiers, **input_definition)
         if other_identifiers.present?
           [identifier, *other_identifiers].compact.each do |input_identifier|

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -225,7 +225,7 @@ module Inferno
         if other_identifiers.present?
           [identifier, *other_identifiers].compact.each do |input_identifier|
             inputs << input_identifier
-            config.add_input(identifier)
+            config.add_input(input_identifier)
           end
         else
           inputs << identifier

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -355,6 +355,15 @@ module Inferno
       def test_count
         @test_count ||= children&.reduce(0) { |sum, child| sum + child.test_count } || 0
       end
+
+      def contained_required_inputs(prior_outputs = [])
+        required_inputs = inputs.select { |input|
+                            (input[:optional].nil? || !input[:optional]) && !prior_outputs.include?(input[:name])
+                          }.map { |input| input[:name] }
+        children_required_inputs = children.map { |child| child.contained_required_inputs(prior_outputs) }.flatten
+        prior_outputs.concat(outputs)
+        (required_inputs + children_required_inputs).flatten.uniq
+      end
     end
   end
 end

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -50,5 +50,11 @@ module Inferno
         super("No '#{validator_name}' validator found")
       end
     end
+
+    class RequiredInputsNotFound < RuntimeError
+      def initialize(missing_inputs)
+        super("Missing the following required inputs: #{missing_inputs.join(', ')}")
+      end
+    end
   end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -106,15 +106,15 @@ RSpec.describe Inferno::DSL::Runnable do
     end
   end
 
-  describe '.get_missing_inputs' do
+  describe '.missing_inputs' do
     it 'returns missing inputs for a test' do
       example_test = Class.new(Inferno::Entities::Test)
       example_test.input :a, :b, :c
       example_test.input :d, optional: true
-      missing_inputs = example_test.get_missing_inputs([{ name: 'a', value: 'a' }])
+      missing_inputs = example_test.missing_inputs([{ name: 'a', value: 'a' }])
       expect(missing_inputs).to eq(['b', 'c'])
 
-      missing_inputs = example_test.get_missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
+      missing_inputs = example_test.missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
                                                         { name: 'c', value: 'c' }])
       expect(missing_inputs).to eq([])
     end
@@ -126,10 +126,10 @@ RSpec.describe Inferno::DSL::Runnable do
         input :a, :b, :c
         input :d, optional: true
       end
-      missing_inputs = example_test_group.get_missing_inputs([{ name: 'a', value: 'a' }, { name: 'e', value: 'e' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'e', value: 'e' }])
       expect(missing_inputs).to eq(['f', 'b', 'c'])
 
-      missing_inputs = example_test_group.get_missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
+      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
                                                               { name: 'c', value: 'c' }, { name: 'e', value: 'e' },
                                                               { name: 'f', value: 'f' }])
       expect(missing_inputs).to eq([])
@@ -144,7 +144,7 @@ RSpec.describe Inferno::DSL::Runnable do
       example_test_group.test 'child test uses output' do
         input :c, :d
       end
-      missing_inputs = example_test_group.get_missing_inputs([{ name: 'a', value: 'a' }, { name: 'd', value: 'd' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'd', value: 'd' }])
       expect(missing_inputs).to eq(['b'])
     end
 
@@ -156,7 +156,7 @@ RSpec.describe Inferno::DSL::Runnable do
       example_test_group.test 'child test with output' do
         output :a
       end
-      missing_inputs = example_test_group.get_missing_inputs([{ name: 'b', value: 'b' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'b', value: 'b' }])
       expect(missing_inputs).to eq(['a'])
     end
   end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Inferno::DSL::Runnable do
       expect(missing_inputs).to eq(['b', 'c'])
 
       missing_inputs = example_test.missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
-                                                        { name: 'c', value: 'c' }])
+                                                    { name: 'c', value: 'c' }])
       expect(missing_inputs).to eq([])
     end
 
@@ -130,8 +130,8 @@ RSpec.describe Inferno::DSL::Runnable do
       expect(missing_inputs).to eq(['f', 'b', 'c'])
 
       missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
-                                                              { name: 'c', value: 'c' }, { name: 'e', value: 'e' },
-                                                              { name: 'f', value: 'f' }])
+                                                          { name: 'c', value: 'c' }, { name: 'e', value: 'e' },
+                                                          { name: 'f', value: 'f' }])
       expect(missing_inputs).to eq([])
     end
 


### PR DESCRIPTION
This PR lets you specify inputs as optional. I decided to default inputs to required, and you have to specify that it's optional in the input definition. The client won't let you submit until you fill in something for all required fields. If you use postman to create a test run without all the required inputs, then you'll get back an error saying which inputs you're missing.

