### PR TITLE
Fi 1312 run as group

### DIFF
--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -1,0 +1,44 @@
+import React, { FC, Fragment } from 'react';
+import { Tooltip, IconButton } from '@material-ui/core';
+import PlayArrowIcon from '@material-ui/icons/PlayArrow';
+import {
+  TestGroup,
+  RunnableType,
+  TestSuite,
+  Test,
+  runnableIsTestSuite,
+} from 'models/testSuiteModels';
+
+export interface TestRunButtonProps {
+  runnable: TestSuite | TestGroup | Test;
+  runTests: (runnableType: RunnableType, runnableId: string) => void;
+  testRunInProgress: boolean;
+}
+
+const TestRunButton: FC<TestRunButtonProps> = ({ runTests, runnable, testRunInProgress }) => {
+  const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
+  const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
+  const runButton = showRunButton ? (
+    <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
+      <div>
+        <IconButton
+          disabled={testRunInProgress}
+          edge="end"
+          size="small"
+          onClick={() => {
+            runTests(runnableType, runnable.id);
+          }}
+          data-testid={`runButton-${runnable.id}`}
+        >
+          <PlayArrowIcon />
+        </IconButton>
+      </div>
+    </Tooltip>
+  ) : (
+    <Fragment />
+  );
+
+  return runButton;
+};
+
+export default TestRunButton;

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -254,7 +254,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     <div className={styles.testSuiteMain}>
       {testRunProgressBar()}
       <TestSuiteTreeComponent
-        {...test_suite}
+        testSuite={test_suite}
         runTests={runTests}
         selectedRunnable={selectedRunnable}
         testRunInProgress={testRunNeedsProgressBar(testRun)}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
-import { TestGroup, RunnableType, TestSuite, runnableIsTestSuite } from 'models/testSuiteModels';
-import { Card, IconButton, List, Tooltip } from '@material-ui/core';
+import { TestGroup, RunnableType, TestSuite } from 'models/testSuiteModels';
+import { Card, List } from '@material-ui/core';
 import ResultIcon from './ResultIcon';
-import PlayArrowIcon from '@material-ui/icons/PlayArrow';
+import TestRunButton from '../TestRunButton/TestRunButton';
 
 interface TestGroupCardProps {
   runnable: TestSuite | TestGroup;
@@ -19,25 +19,6 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
 }) => {
   const styles = useStyles();
 
-  const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
-  const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
-  const runButton = showRunButton ? (
-    <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-      <div>
-        <IconButton
-          disabled={testRunInProgress}
-          edge="end"
-          size="small"
-          onClick={() => {
-            runTests(runnableType, runnable.id);
-          }}
-          data-testid={`${runnable.id}-run-button`}
-        >
-          <PlayArrowIcon />
-        </IconButton>
-      </div>
-    </Tooltip>
-  ) : null;
   return (
     <Card className={styles.testGroupCard} variant="outlined">
       <div className={styles.testGroupCardHeader}>
@@ -45,7 +26,11 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
           <ResultIcon result={runnable.result} />
         </span>
         <span className={styles.testGroupCardHeaderText}>{runnable.title}</span>
-        {runButton}
+        <TestRunButton
+          runnable={runnable}
+          runTests={runTests}
+          testRunInProgress={testRunInProgress}
+        />
       </div>
       <List className={styles.testGroupCardList}>{children}</List>
     </Card>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
-import { TestGroup, RunnableType, TestSuite } from 'models/testSuiteModels';
+import { TestGroup, RunnableType, TestSuite, runnableIsTestSuite } from 'models/testSuiteModels';
 import { Card, IconButton, List, Tooltip } from '@material-ui/core';
 import ResultIcon from './ResultIcon';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
@@ -20,7 +20,25 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
   const styles = useStyles();
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
-
+  const showRunButton =
+    runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
+  const runButton = showRunButton ? (
+    <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
+      <div>
+        <IconButton
+          disabled={testRunInProgress}
+          edge="end"
+          size="small"
+          onClick={() => {
+            runTests(runnableType, runnable.id);
+          }}
+          data-testid={`${runnable.id}-run-button`}
+        >
+          <PlayArrowIcon />
+        </IconButton>
+      </div>
+    </Tooltip>
+  ) : null;
   return (
     <Card className={styles.testGroupCard} variant="outlined">
       <div className={styles.testGroupCardHeader}>
@@ -28,21 +46,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
           <ResultIcon result={runnable.result} />
         </span>
         <span className={styles.testGroupCardHeaderText}>{runnable.title}</span>
-        <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-          <div>
-            <IconButton
-              disabled={testRunInProgress}
-              edge="end"
-              size="small"
-              onClick={() => {
-                runTests(runnableType, runnable.id);
-              }}
-              data-testid={`${runnable.id}-run-button`}
-            >
-              <PlayArrowIcon />
-            </IconButton>
-          </div>
-        </Tooltip>
+        {runButton}
       </div>
       <List className={styles.testGroupCardList}>{children}</List>
     </Card>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -20,8 +20,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
   const styles = useStyles();
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
-  const showRunButton =
-    runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
+  const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
   const runButton = showRunButton ? (
     <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
       <div>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -24,10 +24,29 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
   result,
   id,
   runTests,
+  user_runnable,
   testRunInProgress,
 }) => {
   const styles = useStyles();
-
+  const runButton = user_runnable ? (
+    <ListItemSecondaryAction>
+      <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
+        <div>
+          <IconButton
+            disabled={testRunInProgress}
+            edge="end"
+            size="small"
+            onClick={() => {
+              runTests(RunnableType.TestGroup, id);
+            }}
+            data-testid={`${id}-run-button`}
+          >
+            <PlayArrowIcon />
+          </IconButton>
+        </div>
+      </Tooltip>
+    </ListItemSecondaryAction>
+  ) : null;
   return (
     <ListItem className={styles.listItem}>
       <ListItemIcon>
@@ -42,23 +61,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         secondary={result?.result_message}
       />
       <div className={styles.testIcon}>{<ResultIcon result={result} />}</div>
-      <ListItemSecondaryAction>
-        <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-          <div>
-            <IconButton
-              disabled={testRunInProgress}
-              edge="end"
-              size="small"
-              onClick={() => {
-                runTests(RunnableType.TestGroup, id);
-              }}
-              data-testid={`${id}-run-button`}
-            >
-              <PlayArrowIcon />
-            </IconButton>
-          </div>
-        </Tooltip>
-      </ListItemSecondaryAction>
+      {runButton}
     </ListItem>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -1,52 +1,23 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
-import {
-  IconButton,
-  Link,
-  ListItem,
-  ListItemIcon,
-  ListItemSecondaryAction,
-  ListItemText,
-  Tooltip,
-} from '@material-ui/core';
+import { Link, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import { RunnableType, TestGroup } from 'models/testSuiteModels';
-import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import FolderIcon from '@material-ui/icons/Folder';
 import ResultIcon from './ResultIcon';
+import TestRunButton from '../TestRunButton/TestRunButton';
 
-interface TestGroupListItemProps extends TestGroup {
+interface TestGroupListItemProps {
+  testGroup: TestGroup;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   testRunInProgress: boolean;
 }
 
 const TestGroupListItem: FC<TestGroupListItemProps> = ({
-  title,
-  result,
-  id,
+  testGroup,
   runTests,
-  user_runnable,
   testRunInProgress,
 }) => {
   const styles = useStyles();
-  const runButton = user_runnable ? (
-    <ListItemSecondaryAction>
-      <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-        <div>
-          <IconButton
-            disabled={testRunInProgress}
-            edge="end"
-            size="small"
-            onClick={() => {
-              runTests(RunnableType.TestGroup, id);
-            }}
-            data-testid={`${id}-run-button`}
-          >
-            <PlayArrowIcon />
-          </IconButton>
-        </div>
-      </Tooltip>
-    </ListItemSecondaryAction>
-  ) : null;
   return (
     <ListItem className={styles.listItem}>
       <ListItemIcon>
@@ -54,14 +25,18 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
       </ListItemIcon>
       <ListItemText
         primary={
-          <Link color="inherit" href={`#${id}`}>
-            {title}
+          <Link color="inherit" href={`#${testGroup.id}`}>
+            {testGroup.title}
           </Link>
         }
-        secondary={result?.result_message}
+        secondary={testGroup.result?.result_message}
       />
-      <div className={styles.testIcon}>{<ResultIcon result={result} />}</div>
-      {runButton}
+      <div className={styles.testIcon}>{<ResultIcon result={testGroup.result} />}</div>
+      <TestRunButton
+        runnable={testGroup}
+        runTests={runTests}
+        testRunInProgress={testRunInProgress}
+      />
     </ListItem>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -37,6 +37,7 @@ const TestListItem: FC<TestListItemProps> = ({
   result,
   id,
   description,
+  user_runnable,
   runTests,
   updateRequest,
   testRunInProgress,
@@ -93,6 +94,26 @@ const TestListItem: FC<TestListItemProps> = ({
       'No description'
     );
 
+  const runButton = user_runnable ? (
+    <ListItemSecondaryAction>
+      <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
+        <div>
+          <IconButton
+            disabled={testRunInProgress}
+            edge="end"
+            size="small"
+            onClick={() => {
+              runTests(RunnableType.Test, id);
+            }}
+            data-testid={`${id}-run-button`}
+          >
+            <PlayArrowIcon />
+          </IconButton>
+        </div>
+      </Tooltip>
+    </ListItemSecondaryAction>
+  ) : null;
+
   return (
     <Fragment>
       <Box className={styles.listItem}>
@@ -102,23 +123,7 @@ const TestListItem: FC<TestListItemProps> = ({
           {messagesBadge}
           {requestsBadge}
           {expandButton}
-          <ListItemSecondaryAction>
-            <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-              <div>
-                <IconButton
-                  disabled={testRunInProgress}
-                  edge="end"
-                  size="small"
-                  onClick={() => {
-                    runTests(RunnableType.Test, id);
-                  }}
-                  data-testid={`${id}-run-button`}
-                >
-                  <PlayArrowIcon />
-                </IconButton>
-              </div>
-            </Tooltip>
-          </ListItemSecondaryAction>
+          {runButton}
         </ListItem>
         {result?.result_message ? (
           <ReactMarkdown className={styles.resultMessageMarkdown}>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -8,14 +8,12 @@ import {
   Divider,
   IconButton,
   ListItem,
-  ListItemSecondaryAction,
   ListItemText,
   Tab,
   Tabs,
   Tooltip,
 } from '@material-ui/core';
 import { RunnableType, Test, Request } from 'models/testSuiteModels';
-import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import TabPanel from './TabPanel';
 import MessagesList from './MessagesList';
 import RequestsList from './RequestsList';
@@ -25,19 +23,17 @@ import MailIcon from '@material-ui/icons/Mail';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ReactMarkdown from 'react-markdown';
+import TestRunButton from '../../TestRunButton/TestRunButton';
 
-interface TestListItemProps extends Test {
+interface TestListItemProps {
+  test: Test;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   updateRequest: (requestId: string, resultId: string, request: Request) => void;
   testRunInProgress: boolean;
 }
 
 const TestListItem: FC<TestListItemProps> = ({
-  title,
-  result,
-  id,
-  description,
-  user_runnable,
+  test,
   runTests,
   updateRequest,
   testRunInProgress,
@@ -48,11 +44,11 @@ const TestListItem: FC<TestListItemProps> = ({
   const [panelIndex, setPanelIndex] = React.useState(0);
 
   const messagesBadge =
-    result?.messages && result.messages.length > 0 ? (
-      <Tooltip className={styles.testBadge} title={`${result.messages.length} messages`}>
+    test.result?.messages && test.result.messages.length > 0 ? (
+      <Tooltip className={styles.testBadge} title={`${test.result.messages.length} messages`}>
         <Chip
           variant="outlined"
-          label={result.messages.length}
+          label={test.result.messages.length}
           avatar={<MailIcon />}
           onClick={() => {
             setPanelIndex(1);
@@ -63,11 +59,11 @@ const TestListItem: FC<TestListItemProps> = ({
     ) : null;
 
   const requestsBadge =
-    result?.requests && result.requests.length > 0 ? (
-      <Tooltip className={styles.testBadge} title={`${result.requests.length} http requests`}>
+    test.result?.requests && test.result.requests.length > 0 ? (
+      <Tooltip className={styles.testBadge} title={`${test.result.requests.length} http requests`}>
         <Chip
           variant="outlined"
-          label={result.requests.length}
+          label={test.result.requests.length}
           avatar={<PublicIcon />}
           onClick={() => {
             setPanelIndex(2);
@@ -88,46 +84,30 @@ const TestListItem: FC<TestListItemProps> = ({
   );
 
   const testDescription =
-    description && description.length > 0 ? (
-      <ReactMarkdown>{description}</ReactMarkdown>
+    test.description && test.description.length > 0 ? (
+      <ReactMarkdown>{test.description}</ReactMarkdown>
     ) : (
       'No description'
     );
-
-  const runButton = user_runnable ? (
-    <ListItemSecondaryAction>
-      <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-        <div>
-          <IconButton
-            disabled={testRunInProgress}
-            edge="end"
-            size="small"
-            onClick={() => {
-              runTests(RunnableType.Test, id);
-            }}
-            data-testid={`${id}-run-button`}
-          >
-            <PlayArrowIcon />
-          </IconButton>
-        </div>
-      </Tooltip>
-    </ListItemSecondaryAction>
-  ) : null;
 
   return (
     <Fragment>
       <Box className={styles.listItem}>
         <ListItem>
-          <div className={styles.testIcon}>{<ResultIcon result={result} />}</div>
-          <ListItemText primary={title} />
+          <div className={styles.testIcon}>{<ResultIcon result={test.result} />}</div>
+          <ListItemText primary={test.title} />
           {messagesBadge}
           {requestsBadge}
           {expandButton}
-          {runButton}
+          <TestRunButton
+            runnable={test}
+            runTests={runTests}
+            testRunInProgress={testRunInProgress}
+          />
         </ListItem>
-        {result?.result_message ? (
+        {test.result?.result_message ? (
           <ReactMarkdown className={styles.resultMessageMarkdown}>
-            {result.result_message}
+            {test.result.result_message}
           </ReactMarkdown>
         ) : null}
       </Box>
@@ -151,12 +131,12 @@ const TestListItem: FC<TestListItemProps> = ({
           <Divider />
         </TabPanel>
         <TabPanel currentPanelIndex={panelIndex} index={1}>
-          <MessagesList messages={result?.messages || []} />
+          <MessagesList messages={test.result?.messages || []} />
         </TabPanel>
         <TabPanel currentPanelIndex={panelIndex} index={2}>
           <RequestsList
-            requests={result?.requests || []}
-            resultId={result?.id || ''}
+            requests={test.result?.requests || []}
+            resultId={test.result?.id || ''}
             updateRequest={updateRequest}
           />
         </TabPanel>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteDetailsPanel.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteDetailsPanel.tsx
@@ -27,7 +27,7 @@ const TestSuiteDetailsPanel: FC<TestSuiteDetailsPanelProps> = ({
       return (
         <TestGroupListItem
           key={`li-${testGroup.id}`}
-          {...testGroup}
+          testGroup={testGroup}
           runTests={runTests}
           testRunInProgress={testRunInProgresss}
         />
@@ -38,7 +38,7 @@ const TestSuiteDetailsPanel: FC<TestSuiteDetailsPanelProps> = ({
       return (
         <TestListItem
           key={`li-${test.id}`}
-          {...test}
+          test={test}
           runTests={runTests}
           updateRequest={updateRequest}
           testRunInProgress={testRunInProgresss}

--- a/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
@@ -18,12 +18,12 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
 }) => {
   let sublist: JSX.Element[] = [];
   if (testGroup.test_groups.length > 0) {
-    sublist = testGroup.test_groups.map((subTestGroup) => (
+    sublist = testGroup.test_groups.map((subTestGroup, index) => (
       <TestGroupTreeItem
         testGroup={subTestGroup}
         runTests={runTests}
         onLabelClick={onLabelClick}
-        key={`ti-${testGroup.id}`}
+        key={`ti-${testGroup.id}-${index}`}
         testRunInProgress={testRunInProgress}
       ></TestGroupTreeItem>
     ));

--- a/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
@@ -3,27 +3,24 @@ import { TestGroup, RunnableType } from 'models/testSuiteModels';
 import TreeItem from '@material-ui/lab/TreeItem';
 import TreeItemLabel from './TreeItemLabel';
 
-export interface TestGroupTreeItemProps extends TestGroup {
+export interface TestGroupTreeItemProps {
+  testGroup: TestGroup;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   onLabelClick: (event: MouseEvent<Element>, id: string) => void;
   testRunInProgress: boolean;
 }
 
 const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
-  title,
-  id,
-  test_groups,
-  result,
-  user_runnable,
+  testGroup,
   runTests,
   onLabelClick,
   testRunInProgress,
 }) => {
   let sublist: JSX.Element[] = [];
-  if (test_groups.length > 0) {
-    sublist = test_groups.map((testGroup) => (
+  if (testGroup.test_groups.length > 0) {
+    sublist = testGroup.test_groups.map((subTestGroup) => (
       <TestGroupTreeItem
-        {...testGroup}
+        testGroup={subTestGroup}
         runTests={runTests}
         onLabelClick={onLabelClick}
         key={`ti-${testGroup.id}`}
@@ -33,19 +30,15 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
   }
   return (
     <TreeItem
-      nodeId={id}
+      nodeId={testGroup.id}
       label={
         <TreeItemLabel
-          id={id}
-          title={title}
+          runnable={testGroup}
           runTests={runTests}
-          result={result}
-          runnableType={RunnableType.TestGroup}
           testRunInProgress={testRunInProgress}
-          user_runnable={user_runnable}
         />
       }
-      onLabelClick={(event) => onLabelClick(event, id)}
+      onLabelClick={(event) => onLabelClick(event, testGroup.id)}
     >
       {sublist}
     </TreeItem>

--- a/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
@@ -14,6 +14,7 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
   id,
   test_groups,
   result,
+  user_runnable,
   runTests,
   onLabelClick,
   testRunInProgress,
@@ -41,6 +42,7 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
           result={result}
           runnableType={RunnableType.TestGroup}
           testRunInProgress={testRunInProgress}
+          user_runnable={user_runnable}
         />
       }
       onLabelClick={(event) => onLabelClick(event, id)}

--- a/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
@@ -86,6 +86,7 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
                   result={result}
                   runnableType={RunnableType.TestSuite}
                   testRunInProgress={testRunInProgress}
+                  user_runnable={true}
                 />
               }
               onLabelClick={(event) => treeItemLabelClick(event, id)}

--- a/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
@@ -10,7 +10,8 @@ import TestGroupTreeItem from './TestGroupTreeItem';
 import TreeItemLabel from './TreeItemLabel';
 import { useHistory } from 'react-router-dom';
 
-export interface TestSuiteTreeProps extends TestSuite {
+export interface TestSuiteTreeProps {
+  testSuite: TestSuite;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   selectedRunnable: string;
   testRunInProgress: boolean;
@@ -26,10 +27,7 @@ function addDefaultExpanded(testGroups: TestGroup[], defaultExpanded: string[]):
 }
 
 const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
-  title,
-  id,
-  test_groups,
-  result,
+  testSuite,
   selectedRunnable,
   runTests,
   testRunInProgress,
@@ -37,9 +35,9 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
   const styles = useStyles();
   const history = useHistory();
 
-  const defaultExpanded: string[] = [id];
-  if (test_groups) {
-    addDefaultExpanded(test_groups, defaultExpanded);
+  const defaultExpanded: string[] = [testSuite.id];
+  if (testSuite.test_groups) {
+    addDefaultExpanded(testSuite.test_groups, defaultExpanded);
   }
   const [expanded, setExpanded] = React.useState(defaultExpanded);
 
@@ -53,13 +51,13 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
     setExpanded(nodeIds as string[]);
   }
 
-  if (test_groups) {
-    const testGroupList = test_groups.map((testGroup) => (
+  if (testSuite.test_groups) {
+    const testGroupList = testSuite.test_groups.map((testGroup) => (
       <TestGroupTreeItem
-        {...testGroup}
         key={testGroup.id}
         data-testid={`${testGroup.id}-treeitem`}
         onLabelClick={treeItemLabelClick}
+        testGroup={testGroup}
         runTests={runTests}
         testRunInProgress={testRunInProgress}
       />
@@ -77,19 +75,15 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
           >
             <TreeItem
               classes={{ content: styles.treeRoot }}
-              nodeId={id}
+              nodeId={testSuite.id}
               label={
                 <TreeItemLabel
-                  id={id}
-                  title={title}
+                  runnable={testSuite}
                   runTests={runTests}
-                  result={result}
-                  runnableType={RunnableType.TestSuite}
                   testRunInProgress={testRunInProgress}
-                  user_runnable={true}
                 />
               }
-              onLabelClick={(event) => treeItemLabelClick(event, id)}
+              onLabelClick={(event) => treeItemLabelClick(event, testSuite.id)}
             >
               {testGroupList}
             </TreeItem>
@@ -98,7 +92,7 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
       </Card>
     );
   } else {
-    return <div>{title}</div>;
+    return <div>{testSuite.title}</div>;
   }
 };
 

--- a/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
@@ -12,6 +12,7 @@ export interface TreeItemLabelProps {
   runnableType: RunnableType;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   testRunInProgress: boolean;
+  user_runnable?: boolean;
 }
 
 const TreeItemLabel: FC<TreeItemLabelProps> = ({
@@ -21,6 +22,7 @@ const TreeItemLabel: FC<TreeItemLabelProps> = ({
   runTests,
   runnableType,
   testRunInProgress,
+  user_runnable
 }) => {
   const styles = useStyles();
   return (
@@ -29,6 +31,7 @@ const TreeItemLabel: FC<TreeItemLabelProps> = ({
         {title}
       </Typography>
       <CondensedResultIcon result={result} />
+      {user_runnable ? (
       <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
         <div className={styles.buttonWrapper}>
           <IconButton
@@ -41,6 +44,7 @@ const TreeItemLabel: FC<TreeItemLabelProps> = ({
           </IconButton>
         </div>
       </Tooltip>
+      ) : null}
     </div>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
@@ -1,50 +1,29 @@
 import React, { FC } from 'react';
-import { Result, RunnableType } from 'models/testSuiteModels';
-import { IconButton, Typography, Tooltip } from '@material-ui/core';
+import { RunnableType, TestGroup, TestSuite } from 'models/testSuiteModels';
+import { Typography } from '@material-ui/core';
 import useStyles from './styles';
-import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import CondensedResultIcon from './CondensedResultIcon';
+import TestRunButton from '../TestRunButton/TestRunButton';
 
 export interface TreeItemLabelProps {
-  title: string;
-  id: string;
-  result?: Result;
-  runnableType: RunnableType;
+  runnable: TestSuite | TestGroup;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   testRunInProgress: boolean;
-  user_runnable?: boolean;
 }
 
-const TreeItemLabel: FC<TreeItemLabelProps> = ({
-  title,
-  id,
-  result,
-  runTests,
-  runnableType,
-  testRunInProgress,
-  user_runnable,
-}) => {
+const TreeItemLabel: FC<TreeItemLabelProps> = ({ runnable, runTests, testRunInProgress }) => {
   const styles = useStyles();
   return (
-    <div className={styles.labelRoot} data-testid={`tiLabel-${id}`}>
+    <div className={styles.labelRoot} data-testid={`tiLabel-${runnable.id}`}>
       <Typography className={styles.labelText} variant="body2">
-        {title}
+        {runnable.title}
       </Typography>
-      <CondensedResultIcon result={result} />
-      {user_runnable ? (
-        <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-          <div className={styles.buttonWrapper}>
-            <IconButton
-              disabled={testRunInProgress}
-              data-testid={`runButton-${id}`}
-              onClick={() => runTests(runnableType, id)}
-              className={styles.labelRunButton}
-            >
-              <PlayArrowIcon />
-            </IconButton>
-          </div>
-        </Tooltip>
-      ) : null}
+      <CondensedResultIcon result={runnable.result} />
+      <TestRunButton
+        runnable={runnable}
+        runTests={runTests}
+        testRunInProgress={testRunInProgress}
+      />
     </div>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
@@ -22,7 +22,7 @@ const TreeItemLabel: FC<TreeItemLabelProps> = ({
   runTests,
   runnableType,
   testRunInProgress,
-  user_runnable
+  user_runnable,
 }) => {
   const styles = useStyles();
   return (
@@ -32,18 +32,18 @@ const TreeItemLabel: FC<TreeItemLabelProps> = ({
       </Typography>
       <CondensedResultIcon result={result} />
       {user_runnable ? (
-      <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-        <div className={styles.buttonWrapper}>
-          <IconButton
-            disabled={testRunInProgress}
-            data-testid={`runButton-${id}`}
-            onClick={() => runTests(runnableType, id)}
-            className={styles.labelRunButton}
-          >
-            <PlayArrowIcon />
-          </IconButton>
-        </div>
-      </Tooltip>
+        <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
+          <div className={styles.buttonWrapper}>
+            <IconButton
+              disabled={testRunInProgress}
+              data-testid={`runButton-${id}`}
+              onClick={() => runTests(runnableType, id)}
+              className={styles.labelRunButton}
+            >
+              <PlayArrowIcon />
+            </IconButton>
+          </div>
+        </Tooltip>
       ) : null}
     </div>
   );

--- a/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { TestGroup, Test, RunnableType } from 'models/testSuiteModels';
+import { Test, TestGroup, RunnableType } from 'models/testSuiteModels';
 import TestSuiteTree, { TestSuiteTreeProps } from '../TestSuiteTree';
 
 const runTestsMock = jest.fn();

--- a/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
@@ -27,12 +27,14 @@ const test3: Test = {
   title: 'Client registration endpoint secured by transport layer security',
   inputs: [],
   outputs: [],
+  user_runnable: true,
 };
 const test4: Test = {
   id: 'test4',
   title: 'Client registration endpoint accepts POST messages',
   inputs: [],
   outputs: [],
+  user_runnable: true,
 };
 
 const testList1 = [test1, test2];
@@ -45,6 +47,7 @@ const sequence1: TestGroup = {
   id: 'group0',
   inputs: [{ name: 'test input' }],
   outputs: [],
+  user_runnable: true,
 };
 
 const sequence2: TestGroup = {
@@ -54,6 +57,7 @@ const sequence2: TestGroup = {
   id: 'group1',
   inputs: [{ name: 'second input' }],
   outputs: [],
+  user_runnable: true,
 };
 
 const nestedGroup: TestGroup = {
@@ -63,6 +67,7 @@ const nestedGroup: TestGroup = {
   id: 'group2',
   inputs: [],
   outputs: [],
+  user_runnable: true,
 };
 
 const parentGroup: TestGroup = {
@@ -72,6 +77,7 @@ const parentGroup: TestGroup = {
   id: 'group3',
   inputs: [],
   outputs: [],
+  user_runnable: true,
 };
 
 const testSuiteTreeProps: TestSuiteTreeProps = {
@@ -80,7 +86,7 @@ const testSuiteTreeProps: TestSuiteTreeProps = {
   test_groups: [sequence1, sequence2, parentGroup],
   runTests: runTestsMock,
   selectedRunnable: 'example suite',
-  testRunInProgress: false,
+  testRunInProgress: false
 };
 
 test('Test tree renders', () => {

--- a/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
@@ -86,7 +86,7 @@ const testSuiteTreeProps: TestSuiteTreeProps = {
   test_groups: [sequence1, sequence2, parentGroup],
   runTests: runTestsMock,
   selectedRunnable: 'example suite',
-  testRunInProgress: false
+  testRunInProgress: false,
 };
 
 test('Test tree renders', () => {

--- a/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Test, TestGroup, RunnableType } from 'models/testSuiteModels';
+import { Test, TestGroup, TestSuite, RunnableType } from 'models/testSuiteModels';
 import TestSuiteTree, { TestSuiteTreeProps } from '../TestSuiteTree';
 
 const runTestsMock = jest.fn();
@@ -80,10 +80,14 @@ const parentGroup: TestGroup = {
   user_runnable: true,
 };
 
-const testSuiteTreeProps: TestSuiteTreeProps = {
+const demoTestSuite: TestSuite = {
   title: 'DemonstrationSuite',
   id: 'example suite',
   test_groups: [sequence1, sequence2, parentGroup],
+};
+
+const testSuiteTreeProps: TestSuiteTreeProps = {
+  testSuite: demoTestSuite,
   runTests: runTestsMock,
   selectedRunnable: 'example suite',
   testRunInProgress: false,
@@ -91,7 +95,7 @@ const testSuiteTreeProps: TestSuiteTreeProps = {
 
 test('Test tree renders', () => {
   render(<TestSuiteTree {...testSuiteTreeProps}></TestSuiteTree>);
-  const treeTitle = screen.getByText(testSuiteTreeProps.title);
+  const treeTitle = screen.getByText(testSuiteTreeProps.testSuite.title);
   expect(treeTitle).toBeVisible();
   const sequence1Title = screen.getByText(sequence1.title);
   expect(sequence1Title).toBeVisible();
@@ -113,15 +117,18 @@ test('Individual tests are not shown by default', () => {
 
 test('Calls setSelectedRunnable when tree item is clicked', () => {
   render(<TestSuiteTree {...testSuiteTreeProps}></TestSuiteTree>);
-  const testSuiteLabel = screen.getByTestId(`tiLabel-${testSuiteTreeProps.id}`);
+  const testSuiteLabel = screen.getByTestId(`tiLabel-${testSuiteTreeProps.testSuite.id}`);
   fireEvent.click(testSuiteLabel);
 });
 
 test('Calls runTests when run button is clicked', () => {
   render(<TestSuiteTree {...testSuiteTreeProps}></TestSuiteTree>);
-  const suiteRunButton = screen.getByTestId(`runButton-${testSuiteTreeProps.id}`);
+  const suiteRunButton = screen.getByTestId(`runButton-${testSuiteTreeProps.testSuite.id}`);
   fireEvent.click(suiteRunButton);
-  expect(runTestsMock).toHaveBeenCalledWith(RunnableType.TestSuite, testSuiteTreeProps.id);
+  expect(runTestsMock).toHaveBeenCalledWith(
+    RunnableType.TestSuite,
+    testSuiteTreeProps.testSuite.id
+  );
 
   const groupRunButton = screen.getByTestId(`runButton-${sequence1.id}`);
   fireEvent.click(groupRunButton);

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -60,6 +60,7 @@ export interface Test {
   inputs: TestInput[];
   outputs: TestOutput[];
   description?: string;
+  user_runnable?: boolean;
 }
 
 export interface TestGroup {
@@ -71,6 +72,8 @@ export interface TestGroup {
   result?: Result;
   tests: Test[];
   description?: string;
+  run_as_group?: boolean;
+  user_runnable?: boolean;
 }
 
 export interface TestSuite {
@@ -99,7 +102,11 @@ export interface TestRun {
   results?: Result[] | null;
   status?: 'queued' | 'running' | 'waiting' | 'done';
   test_count?: number;
-  testGroupId?: string;
-  testSuiteId?: string;
-  testId?: string;
+  test_group_id?: string;
+  test_suite_id?: string;
+  test_id?: string;
+}
+
+export function runnableIsTestSuite(runnable: TestSuite | TestGroup | Test): runnable is TestSuite {
+  return (runnable as TestGroup).inputs == undefined;
 }

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -71,5 +71,63 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         run { pass }
       end
     end
+
+    group do
+      id 'run_as_group_examples'
+      title 'Run as Group Examples'
+
+      group do
+        id 'run_as_group_multi'
+        title 'Run as Group On (nested groups)'
+        run_as_group
+
+        group do
+          id 'run_as_group_on'
+          title 'Run as group also set at this level (should not be runnable)'
+          run_as_group
+
+          test do
+            title 'Test should not be runnable'
+            run { pass }
+          end
+
+          test do
+            title 'Test should not be runnable'
+            run { pass }
+          end
+        end
+
+        group do
+          id 'run_as_group_off'
+          title 'Run as group not set at this level (should not be runnable)'
+
+          test do
+            title 'Test should not be runnable'
+            run { pass }
+          end
+
+          test do
+            title 'Test should not be runnable'
+            run { pass }
+          end
+        end
+      end
+
+      group do
+        id 'run_as_group_single'
+        title 'Run as Group On (no nested groups)'
+        run_as_group
+
+        test do
+          title 'Test should not be runnable'
+          run { pass }
+        end
+
+        test do
+          title 'Test should not be runnable'
+          run { pass }
+        end
+      end
+    end
   end
 end

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -507,6 +507,9 @@ definitions:
       test_count:
         type: "number"
         readOnly: true
+      user_runnable:
+        type: "boolean"
+        readonly: true
   Test:
     type: "object"
     required:
@@ -523,6 +526,9 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Input"
+      user_runnable:
+        type: "boolean"
+        readonly: true
   Input:
     type: "object"
     required:

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -25,6 +25,7 @@ module Inferno
             missing_inputs = test_run.runnable.missing_inputs(params[:inputs])
 
             raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs.any?
+            raise Inferno::Exceptions::NotUserRunnableException unless test_run.runnable.user_runnable?
 
             self.body = serialize(test_run)
 
@@ -38,7 +39,8 @@ module Inferno
 
             Jobs.perform(Jobs::ExecuteTestRun, test_run.id)
           rescue Sequel::ValidationFailed, Sequel::ForeignKeyConstraintViolation,
-                 Inferno::Exceptions::RequiredInputsNotFound => e
+                 Inferno::Exceptions::RequiredInputsNotFound,
+                 Inferno::Exceptions::NotUserRunnableException => e
             self.body = { errors: e.message }.to_json
             self.status = 422
           rescue StandardError => e

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -7,6 +7,7 @@ module Inferno
         field :input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
         field :description
+        field :user_runnable?, name: :user_runnable
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -7,7 +7,8 @@ module Inferno
         field :title
         field :description
         field :test_count
-        # field :run_as_group
+        field :run_as_group?, name: :run_as_group
+        field :user_runnable?, name: :user_runnable
 
         association :groups, name: :test_groups, blueprint: TestGroup
         association :tests, blueprint: Test

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -371,6 +371,13 @@ module Inferno
 
         required_inputs.map(&:to_s) - submitted_inputs.map { |input| input[:name] }
       end
+
+      def user_runnable?
+        @user_runnable ||= parent.nil? ||
+                           !parent.respond_to?(:user_runnable?) ||
+                           !parent.respond_to?(:run_as_group?) ||
+                           (parent.user_runnable? && !parent.run_as_group?)
+      end
     end
   end
 end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -374,7 +374,6 @@ module Inferno
 
       def user_runnable?
         @user_runnable ||= parent.nil? ||
-                           !parent.respond_to?(:user_runnable?) ||
                            !parent.respond_to?(:run_as_group?) ||
                            (parent.user_runnable? && !parent.run_as_group?)
       end

--- a/lib/inferno/entities/test_group.rb
+++ b/lib/inferno/entities/test_group.rb
@@ -79,6 +79,14 @@ module Inferno
             test_group_id: id
           }
         end
+
+        def run_as_group(value = true) # rubocop:disable Style/OptionalBooleanParameter
+          @run_as_group = value
+        end
+
+        def run_as_group?
+          @run_as_group || false
+        end
       end
     end
   end

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -56,5 +56,11 @@ module Inferno
         super("Missing the following required inputs: #{missing_inputs.join(', ')}")
       end
     end
+
+    class NotUserRunnableException < RuntimeError
+      def initialize
+        super('The chosen runnable must be run as part of a group')
+      end
+    end
   end
 end

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -79,7 +79,11 @@ RSpec.describe Inferno::TestRunner do
   end
 
   describe 'when running wait group' do
-    let(:group) { Inferno::Repositories::TestSuites.new.find('demo').groups.last }
+    let(:group) do
+      Inferno::Repositories::TestSuites.new.find('demo').groups.find do |group|
+        group.id == 'demo-wait_group'
+      end
+    end
 
     it 'gives a wait result' do
       result = runner.run(group)

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -79,11 +79,7 @@ RSpec.describe Inferno::TestRunner do
   end
 
   describe 'when running wait group' do
-    let(:group) do
-      Inferno::Repositories::TestSuites.new.find('demo').groups.find do |group|
-        group.id == 'demo-wait_group'
-      end
-    end
+    let(:group) { Inferno::Repositories::TestGroups.new.find('demo-wait_group') }
 
     it 'gives a wait result' do
       result = runner.run(group)

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
   it 'serializes a group' do
     serialized_group = JSON.parse(described_class.render(group))
 
-    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title', 'test_count', 'test_groups', 'tests']
+    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title', 'test_count', 'test_groups', 'tests',
+                     'run_as_group', 'user_runnable']
 
     expect(serialized_group.keys).to match_array(expected_keys)
     expect(serialized_group['id']).to eq(group.id.to_s)

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Inferno::Web::Serializers::Test do
   it 'serializes a test' do
     serialized_test = JSON.parse(described_class.render(test))
 
-    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title']
+    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title', 'user_runnable']
 
     expect(serialized_test.keys).to match_array(expected_keys)
     expect(serialized_test['id']).to eq(test.id.to_s)

--- a/spec/requests/test_runs_spec.rb
+++ b/spec/requests/test_runs_spec.rb
@@ -91,15 +91,9 @@ RSpec.describe '/test_runs' do
         }
       end
       let(:run_as_group_test_session) { repo_create(:test_session, test_suite_id: 'demo') }
+      let(:run_as_group_test) { run_as_group_group.tests.first }
       let(:run_as_group_group) do
-        Inferno::Repositories::TestSuites.new.find('demo').groups.find do |group|
-          group.id == 'demo-run_as_group_examples'
-        end.groups.first.groups.first
-      end
-      let(:run_as_group_test) do
-        Inferno::Repositories::TestSuites.new.find('demo').groups.find do |group|
-          group.id == 'demo-run_as_group_examples'
-        end.groups.first.groups.first.tests.first
+        Inferno::Repositories::TestGroups.new.find('demo-run_as_group_examples').groups.first.groups.first
       end
 
       it 'returns a 422 error for an unrunnable group' do


### PR DESCRIPTION
This PR adds the ability to mark test groups as run_as_group. This means that anything within that group cannot be run individually. You must run the highest level group that's marked as run_as_group.
