### PR TITLE
FI-1337: Add scratch

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -246,5 +246,13 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
 
       run { info "Received the following 'textarea' variable: '#{textarea}''" }
     end
+
+    test 'write to scratch' do
+      run { scratch[:abc] = 'xyz' }
+    end
+
+    test 'read from scratch' do
+      run { assert scratch[:abc] == 'xyz' }
+    end
   end
 end

--- a/lib/inferno/entities/test.rb
+++ b/lib/inferno/entities/test.rb
@@ -13,10 +13,11 @@ module Inferno
       def_delegators 'self.class', :title, :id, :block, :inputs, :outputs
 
       attr_accessor :result_message
-      attr_reader :test_session_id
+      attr_reader :test_session_id, :scratch
 
       def initialize(**params)
         params[:inputs]&.each { |key, value| instance_variable_set("@#{key}", value) }
+        @scratch = params[:scratch]
         @test_session_id = params[:test_session_id]
       end
 

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -38,13 +38,13 @@ module Inferno
       run_results.values
     end
 
-    def run(runnable)
+    def run(runnable, scratch = {})
       if runnable < Entities::Test
-        return existing_test_result(runnable) || run_test(runnable) if resuming
+        return existing_test_result(runnable) || run_test(runnable, scratch) if resuming
 
-        run_test(runnable)
+        run_test(runnable, scratch)
       else
-        run_group(runnable)
+        run_group(runnable, scratch)
       end
     end
 
@@ -52,11 +52,11 @@ module Inferno
       results_repo.result_for_test_run(runnable.reference_hash.merge(test_run_id: test_run.id))
     end
 
-    def run_test(test)
+    def run_test(test, scratch)
       inputs = load_inputs(test)
 
       input_json_string = JSON.generate(inputs)
-      test_instance = test.new(inputs: inputs, test_session_id: test_session.id)
+      test_instance = test.new(inputs: inputs, test_session_id: test_session.id, scratch: scratch)
 
       result = begin
         test_instance.load_named_requests
@@ -98,10 +98,10 @@ module Inferno
       test_result
     end
 
-    def run_group(group)
+    def run_group(group, scratch)
       results = []
       group.children.each do |child|
-        result = run(child)
+        result = run(child, scratch)
         results << result
         break if results.last.waiting?
       end


### PR DESCRIPTION
This branch adds transient in-memory storage for passing data between tests during a single test run.